### PR TITLE
Final Round of Panoptica v5.2 Initial Errata Additions

### DIFF
--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -290,6 +290,11 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="40f3-05e8-5ddc-636a" field="category"/>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="7d95-f9d1-440a-67bd" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="89f7-b7a1-aab2-e47a" name="Bound Daemon Regent" publicationId="cb13-da24-e6da-75b3" page="17" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -298,6 +303,8 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="40f3-05e8-5ddc-636a" field="category"/>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
       <categoryLinks>
         <categoryLink id="ffef-0edc-ccde-7d6e" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
@@ -659,6 +666,11 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="525"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="40f3-05e8-5ddc-636a" field="category"/>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="f479-3c81-1e42-1b3a" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="519f-866e-e6fe-20e0" name="Bound Daemon Brutes" publicationId="cb13-da24-e6da-75b3" page="18" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -667,6 +679,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <condition field="selections" scope="519f-866e-e6fe-20e0" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="equalTo"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="40f3-05e8-5ddc-636a" field="category"/>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
       <categoryLinks>
         <categoryLink id="6e4a-c4d0-ec9e-672c" name="Daemon Unit Type" hidden="false" targetId="e699-d9cd-e68e-46d9" primary="false"/>
@@ -741,6 +755,176 @@ During a Reaction made in any Phase, a player may not choose to activate a model
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Bound Cor’bax Utterblight" hidden="false" id="4ad9-d3b8-408b-8112" publicationId="cb13-da24-e6da-75b3" page="21">
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Cor’bax Utterblight" hidden="false" id="3335-d31e-9a19-f9ab" publicationId="8775-88f5-cfdd-24f6" page="20">
+          <profiles>
+            <profile name="Bound Cor’bax Utterblight" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="ebdb-abef-62ac-a33" publicationId="cb13-da24-e6da-75b3" page="20">
+              <characteristics>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Daemon (Character, Monstrous, Psyker, Unique, Bound, Heavy)</characteristic>
+                <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">7</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">8</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">9</characteristic>
+                <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">5</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b038-d7ae-54fb-c403"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3008-b7de-a6ca-99cd"/>
+          </constraints>
+          <categoryLinks>
+            <categoryLink name="Daemon Unit-type:" hidden="false" id="c470-4932-9574-92d8" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+            <categoryLink name="Character" hidden="false" id="8cb8-49ed-a9ff-a725" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+            <categoryLink name="Monstrous Sub-type:" hidden="false" id="405a-1ef4-48c7-127" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+            <categoryLink name="Psyker:" hidden="false" id="3f8-ead8-991c-8f11" targetId="6e0c-29ba-a445-8321" primary="false"/>
+            <categoryLink name="Unique Sub-type" hidden="false" id="84f7-20b9-3b98-1823" targetId="aa94-5c65-d1f1-46a4" primary="false"/>
+            <categoryLink name="Heavy Sub-type:" hidden="false" id="b842-8804-11c-6785" targetId="9231-183c-b97b-63f9" primary="false"/>
+          </categoryLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Warlord Trait: Lord of Decay" hidden="false" id="6f24-baab-fafa-f78c" collective="false">
+          <modifiers>
+            <modifier type="set" value="1" field="46a3-f473-a291-2c2">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="4ad9-d3b8-408b-8112" childId="0176-56a3-d590-b103" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="4ad9-d3b8-408b-8112" childId="0176-56a3-d590-b103" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dd3b-ca1-bcfc-84b1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="46a3-f473-a291-2c2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <profiles>
+            <profile name="Warlord Trait: Lord of Decay" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait" hidden="false" id="7976-1ea6-fb85-c46c" publicationId="8775-88f5-cfdd-24f6" page="20">
+              <characteristics>
+                <characteristic name="Text" hidden="false" id="3ccd-90c2-3f80-4191" typeId="c68e-2cda-b67b-baca">Cor’bax Utterblight Unbound may always be selected as an army’s Warlord even if it is not part of the Primary Detachment or an HQ choice. If chosen as the army’s Warlord, Cor’bax Utterblight Unbound automatically has Lord of Decay as its Warlord Trait and may not select any other.
+
+
+Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion (Putrid Corruption) special rule within 3&quot; of Cor’bax Utterblight Unbound can re-roll failed Damage Mitigation rolls provided to them by the Ætheric Dominion (Putrid Corruption) and Feel No Pain (X) special rules. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Cor’bax Utterblight Unbound has not been removed as a casualty.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="Pts" hidden="false" id="62cd-25b5-898f-db8f" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Noxious Maw" hidden="false" id="32c2-26b-f5c8-2bd3" publicationId="8775-88f5-cfdd-24f6" page="20">
+          <profiles>
+            <profile name="Noxious Maw" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="e46d-f7bc-9ced-acb" publicationId="8775-88f5-cfdd-24f6" page="20">
+              <characteristics>
+                <characteristic name="Range" hidden="false" id="9ce2-4079-c7d2-69a" typeId="95ba-cda7-b831-6066">-</characteristic>
+                <characteristic name="Strength" hidden="false" id="a55e-1885-a9f7-bf74" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+                <characteristic name="AP" hidden="false" id="97e7-c858-2744-a67f" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                <characteristic name="Type" hidden="false" id="6161-fe69-4370-b3a9" typeId="2f86-c8b4-b3b4-3ff9">Melee, Murderous Strike (4+)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Murderous Strike (X)" hidden="false" id="79f0-843a-3a86-9c74" type="rule" targetId="93b9-1454-0e7c-42ae">
+              <modifiers>
+                <modifier type="set" value="Murderous Strike (4+)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e8f2-bff1-513c-1be9"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9c80-599f-7178-c6cf"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="Pts" hidden="false" id="3242-d71a-1dc8-c18" typeId="d2ee-04cb-5f8a-2642" value="430"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Putrid Corruption" hidden="false" id="eddf-bc54-dc8c-28f4" type="selectionEntry" targetId="b7db-bf16-47c5-dc05">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f07f-129b-576d-5e68"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Warlord" hidden="false" id="77db-8a17-a771-69bf" collective="false" targetId="0176-56a3-d590-b103" type="selectionEntry"/>
+        <entryLink import="true" name="Samus, Ka’bandha &amp; Cor&apos;bax Warlord stuff" hidden="false" id="c0bf-334d-441a-b738" collective="false" targetId="092d-3716-36f8-8988" type="selectionEntry"/>
+        <entryLink import="true" name="Psychic Discipline: Biomancy" hidden="false" id="4742-a0dd-5477-cda2" type="selectionEntry" targetId="861c-3744-c4ff-ef6c">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2506-37ac-76e9-11cb"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="146f-e297-ee02-ffa7"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <infoLinks>
+        <infoLink name="Æthereal Invulnerability (X)" hidden="false" id="882c-235f-a53b-62fd" targetId="e05e-ed23-64fb-a535" type="rule">
+          <modifiers>
+            <modifier type="set" value="Æthereal Invulnerability (4+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Empyrean Avatar" hidden="false" id="849d-6b60-5bf-8f8e" type="rule" targetId="c694-20c8-455-baca"/>
+        <infoLink name="It Will Not Die (X)" hidden="false" id="faf4-6a97-b605-b639" targetId="2784-d0be-a4e2-890f" type="rule">
+          <modifiers>
+            <modifier type="set" value="It Will Not Die (4+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Traitor" hidden="false" id="5303-71f3-eca7-1f98" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink name="Adamantium Will (X+)" hidden="false" id="bb25-b0e0-56ed-fb35" targetId="4380-44a5-f01a-d964" type="rule">
+          <modifiers>
+            <modifier type="set" value="Adamantium Will (3+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hammer of Wrath (X)" hidden="false" id="91ac-b52f-671f-edb9" targetId="aec0-c3aa-1e4e-1779" type="rule">
+          <modifiers>
+            <modifier type="set" value="Hammer of Wrath (D3+1)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Bulky (X)" hidden="false" id="68b0-dd7e-5016-58ac" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (6)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Bound Malefica" hidden="false" id="2d38-240c-7650-3329" targetId="e2de-47bf-2a1c-45e5" type="rule"/>
+      </infoLinks>
+      <rules>
+        <rule name="Herald of Pestilence" hidden="false" id="b33d-8b1d-d8f1-c976" publicationId="8775-88f5-cfdd-24f6" page="20">
+          <description>Cor’bax Utterblight Unbound is a Psyker and gains the Biomancy Disciplines from the Core Psychic Discipline (see the Warhammer: The Horus Heresy – Age of Darkness Rulebook, page 325) at no additional points cost and may not select any other Psychic Disciplines.</description>
+        </rule>
+        <rule name="Noisome Tide of Flesh" hidden="false" id="25a6-5198-abb1-a54a" publicationId="8775-88f5-cfdd-24f6" page="20">
+          <description>Cor’bax Utterblight Unbound suffers no penalty for moving or  charging through Difficult Terrain. In addition, when Cor’bax Utterblight Unbound is  destroyed, nearby units suffer a Strength 6, AP- Hit for each model within 5&quot; that does not have the Daemon Unit Type. Any unit that suffers one or more Hits from this effect must take an immediate Pinning test. Once all Hits and Pinning tests are resolved, Cor’bax Utterblight Unbound is  then removed from the battlefield.</description>
+        </rule>
+      </rules>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="force" shared="true" id="7a4-9ba8-734c-9705" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="900a-3268-3eae-644a" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink name="Daemon Unit-type:" hidden="false" id="1590-b374-c12a-8669" targetId="e699-d9cd-e68e-46d9" primary="false"/>
+        <categoryLink name="Character" hidden="false" id="e089-de3d-2053-a344" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
+        <categoryLink name="Monstrous Sub-type:" hidden="false" id="a32f-4b0d-6c3e-3ed0" targetId="7d95-f9d1-440a-67bd" primary="false"/>
+        <categoryLink name="Psyker:" hidden="false" id="87c1-bb7c-d94d-3f19" targetId="6e0c-29ba-a445-8321" primary="false"/>
+        <categoryLink name="Unique Sub-type" hidden="false" id="2b50-6b27-aa8e-b39c" targetId="aa94-5c65-d1f1-46a4" primary="false"/>
+        <categoryLink name="Putrid Corruption" hidden="false" id="a10a-1ef9-7907-a3ed" targetId="8cf6-d802-d054-6a86" primary="false"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="add" value="9231-183c-b97b-63f9" field="category">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="parent" childId="b7db-bf16-47c5-dc05" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="7d95-f9d1-440a-67bd" field="category"/>
+        <modifier type="add" value="6e0c-29ba-a445-8321" field="category"/>
+        <modifier type="add" value="f75a-d5c1-59ba-5c5a" field="category"/>
+        <modifier type="add" value="aa94-5c65-d1f1-46a4" field="category"/>
+        <modifier type="add" value="40f3-05e8-5ddc-636a" field="category"/>
+      </modifiers>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>

--- a/2022 - Daemons - Bound Daemons.cat
+++ b/2022 - Daemons - Bound Daemons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d114-c205-18d5-4e95" name="Daemons - Bound Daemons" revision="2008" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d114-c205-18d5-4e95" name="Daemons - Bound Daemons" revision="2009" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="250f-d164-bb7e-7025" name="Bound Daemon Brutes" hidden="false" collective="false" import="false" targetId="519f-866e-e6fe-20e0" type="selectionEntry">
       <modifiers>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="724d-13c4-628c-f642" name="Daemons - Daemons of the Ruinstorm" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" revision="2011" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="724d-13c4-628c-f642" name="Daemons - Daemons of the Ruinstorm" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" revision="2012" battleScribeVersion="2.03" type="catalogue">
   <entryLinks>
     <entryLink import="false" name="Daemons of the Ruinstorm" hidden="false" type="selectionEntry" id="e271-f450-1c28-5b7b" targetId="afca-3047-fb26-d097">
       <constraints>

--- a/2022 - Daemons - Daemons of the Ruinstorm.cat
+++ b/2022 - Daemons - Daemons of the Ruinstorm.cat
@@ -218,7 +218,7 @@
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bf49-e79d-d174-eb95"/>
               </constraints>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="40"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -239,7 +239,7 @@
             </entryLink>
             <entryLink import="true" name="Immaterial Wings" hidden="false" type="selectionEntry" id="bc4-6f59-2af1-116d" targetId="fd64-626a-d3d4-9b8e">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
             </entryLink>
             <entryLink import="true" name="Ætheric Flight" hidden="false" type="selectionEntry" id="cfc-f8bc-d665-7c0c" targetId="7647-8112-eaf7-fbea">
@@ -276,6 +276,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Hierarch" hidden="false" id="ae8b-ee65-95b6-a8f9" publicationId="8775-88f5-cfdd-24f6" page="7">
@@ -288,7 +289,7 @@
           <profiles>
             <profile name="Hierarch" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="8a95-e077-ac4f-6866" publicationId="8775-88f5-cfdd-24f6" page="7">
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Daemon (Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Daemon (Independent Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
@@ -320,12 +321,6 @@
       </costs>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="d43f-71c8-cbf2-cff0" targetId="caad-e621-38e5-cb5f"/>
-        <entryLink import="true" name="Infernal Armaments" hidden="false" type="selectionEntry" id="40ef-9284-1d09-74c0" targetId="9abc-11e8-9031-d104">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de9-d9cd-9f99-404d"/>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d098-eed3-d888-ab67"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="1655-8fed-b79a-24f6" targetId="0176-56a3-d590-b103"/>
         <entryLink import="true" name="Warlord Traits (Ruinstorm Daemons)" hidden="false" type="selectionEntryGroup" id="f5c1-536d-3f92-a419" targetId="2f76-74c1-d329-d3ab"/>
       </entryLinks>
@@ -405,6 +400,25 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup name="Melee Option" hidden="false" id="37ca-7cdf-3845-bb54" publicationId="9fab-fea7-a93c-2074" page="159">
+          <entryLinks>
+            <entryLink import="true" name="Infernal Armaments" hidden="false" id="40ef-9284-1d09-74c0" type="selectionEntry" targetId="9abc-11e8-9031-d104">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de9-d9cd-9f99-404d"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d098-eed3-d888-ab67"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Sovereign Armaments" hidden="false" id="1b25-b03-a300-c923" type="selectionEntry" targetId="c859-2be-6d66-d3da">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9f80-e3f-5b9d-ba61"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2f4b-9bd3-cae2-5e7e"/>
+          </constraints>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -412,6 +426,8 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" field="category" value="e699-d9cd-e68e-46d9"/>
+        <modifier type="add" field="category" value="4f07-3d45-4f28-a0c6"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harbinger" hidden="false" id="5a2e-abe2-3044-3c1c" publicationId="8775-88f5-cfdd-24f6" page="8">
@@ -434,7 +450,7 @@
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
               </characteristics>
               <modifiers>
                 <modifier type="append" field="ddd7-6f5c-a939-b69e" value="(Heavy)">
@@ -600,6 +616,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Brutes" hidden="false" id="2219-cb60-b52-a36c" publicationId="8775-88f5-cfdd-24f6" page="9">
@@ -683,6 +700,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
       <selectionEntryGroups>
         <selectionEntryGroup name="Weapons" hidden="false" id="5b87-924a-4731-f695">
@@ -742,6 +760,12 @@
             </modifier>
           </modifiers>
         </infoLink>
+        <infoLink name="Furious Charge (X)" hidden="false" id="eec-177e-e86b-8d9" type="rule" targetId="2821-9269-862f-0554" publicationId="9fab-fea7-a93c-2074" page="158">
+          <modifiers>
+            <modifier type="set" value="Furious Charge (1)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Scout" hidden="false" id="43e6-6059-ee00-e1f4" type="rule" targetId="aacf-9a7e-982d-b793" publicationId="9fab-fea7-a93c-2074" page="158"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Daemon Beasts" hidden="false" id="8d09-1913-b79f-5c35" defaultSelectionEntryId="e8d9-781b-531d-9386">
@@ -765,7 +789,7 @@
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">5+</characteristic>
                   </characteristics>
@@ -852,6 +876,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Lesser Daemons" hidden="false" id="157c-7592-a6b9-f96" publicationId="8775-88f5-cfdd-24f6" page="11">
@@ -894,9 +919,6 @@
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
-      <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
-      </costs>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="984b-1653-1706-eaf" targetId="caad-e621-38e5-cb5f"/>
       </entryLinks>
@@ -948,6 +970,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Swarms" hidden="false" id="bb35-e585-a226-28e" publicationId="8775-88f5-cfdd-24f6" page="12">
@@ -1028,6 +1051,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Cavalry" hidden="false" id="b7b5-c59a-768c-276c" publicationId="8775-88f5-cfdd-24f6" page="13">
@@ -1052,7 +1076,7 @@
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
               </characteristics>
               <modifiers>
@@ -1115,6 +1139,12 @@
             </modifier>
           </modifiers>
         </infoLink>
+        <infoLink name="Hit &amp; Run" hidden="false" id="3d7c-84fe-a9f6-6ed3" type="rule" targetId="5986-e960-d432-affd"/>
+        <infoLink name="Bulky (X)" hidden="false" id="dd9d-3fc3-cd55-c8b" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (2)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -1122,6 +1152,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Harriers" hidden="false" id="14c1-3063-c9b4-d99b" publicationId="8775-88f5-cfdd-24f6" page="14">
@@ -1142,7 +1173,7 @@
                 <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
-                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">5+</characteristic>
               </characteristics>
@@ -1191,6 +1222,7 @@
             </modifier>
           </modifiers>
         </infoLink>
+        <infoLink name="Deep Strike" hidden="false" id="5cc0-add-ac52-150a" type="rule" targetId="f1e1-986f-c783-ca9e"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Weapons" hidden="false" id="38df-f8ac-dd92-a3e5" defaultSelectionEntryId="174b-985e-fc0e-beef">
@@ -1218,6 +1250,7 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Greater Ruinstorm Daemon Beast" hidden="false" id="41a0-6caa-af06-3684" publicationId="8775-88f5-cfdd-24f6" page="15">
@@ -1231,18 +1264,18 @@
             <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="6d09-3404-7ce8-b204"/>
           </constraints>
           <profiles>
-            <profile name="Greater Beast" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="aff8-7aeb-79a0-62f3" publicationId="8775-88f5-cfdd-24f6" page="15">
+            <profile name="Greater Beast" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="aff8-7aeb-79a0-62f3" publicationId="9fab-fea7-a93c-2074" page="158">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Daemon (Monstrous)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
-                <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
-                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
+                <characteristic name="S" typeId="e478-41d4-a092-48a8">6</characteristic>
+                <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">5</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
               </characteristics>
               <modifiers>
@@ -1297,6 +1330,11 @@
           </modifiers>
         </infoLink>
         <infoLink id="3fca-6f8-15aa-91c0" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink name="Bulky (X)" hidden="false" id="e79e-8465-8f3-cfe" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (5)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <modifiers>
         <modifier type="add" field="category" value="9231-183c-b97b-63f9">
@@ -1304,24 +1342,26 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="7d95-f9d1-440a-67bd" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Daemon Behemoth" hidden="false" id="240a-1822-9e4f-3080" publicationId="8775-88f5-cfdd-24f6" page="16">
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Ruinstorm Behemoth" hidden="false" id="b128-73e-2b19-55c8" publicationId="8775-88f5-cfdd-24f6" page="16">
           <profiles>
-            <profile name="Ruinstorm Behemoth" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="2d12-8f40-16a4-6826">
+            <profile name="Ruinstorm Behemoth" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" hidden="false" id="2d12-8f40-16a4-6826" publicationId="9fab-fea7-a93c-2074" page="158">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Daemon (Monstrous)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">8</characteristic>
-                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
                 <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">6</characteristic>
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">7</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">5</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
               </characteristics>
               <modifiers>
@@ -1400,6 +1440,11 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink import="true" name="The Ætheric Dominion (Unit)" hidden="false" type="selectionEntryGroup" id="dc61-4e39-99b9-8398" targetId="caad-e621-38e5-cb5f"/>
+        <entryLink import="true" name="The Unmaking" hidden="false" id="8797-9648-22fb-b020" type="selectionEntry" targetId="eb14-1d7a-62f3-60ac">
+          <costs>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+          </costs>
+        </entryLink>
       </entryLinks>
       <infoLinks>
         <infoLink id="c667-25ba-81a5-446d" name="Æthereal Invulnerability (X)" hidden="false" targetId="e05e-ed23-64fb-a535" type="rule">
@@ -1446,6 +1491,8 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="7d95-f9d1-440a-67bd" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ruinstorm Arch-Daemon" hidden="false" id="1fbb-b82e-ae1e-5a12" publicationId="8775-88f5-cfdd-24f6" page="17">
@@ -1520,6 +1567,7 @@
             </modifier>
           </modifiers>
         </infoLink>
+        <infoLink name="Warp Resplendent" hidden="false" id="b6e3-8226-aaa4-5663" type="rule" targetId="9049-4422-5120-ef52"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Behemoth Blade" hidden="false" type="selectionEntry" id="f0a5-4b23-96aa-9de8" targetId="6ede-e07c-24cd-1813">
@@ -1540,7 +1588,7 @@
             </entryLink>
             <entryLink import="true" name="Immaterial Wings" hidden="false" type="selectionEntry" id="8e8a-3519-1fd6-8ae4" targetId="fd64-626a-d3d4-9b8e">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
             </entryLink>
             <entryLink import="true" name="Ætheric Flight" hidden="false" type="selectionEntry" id="218a-b6fd-3f25-1424" targetId="7647-8112-eaf7-fbea">
@@ -1584,6 +1632,8 @@
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="f479-3c81-1e42-1b3a" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ka’bandha Unbound" hidden="false" id="baa5-baed-1a62-c820" publicationId="8775-88f5-cfdd-24f6" page="18">
@@ -1775,6 +1825,12 @@ If Sanguinius is removed as a casualty while fighting in a Challenge against Ka&
         <categoryLink targetId="aa94-5c65-d1f1-46a4" id="f567-1f17-8a16-1bd8" primary="false" name="Unique Sub-type"/>
         <categoryLink targetId="f074-f60a-9aa6-c52a" id="45f7-fd43-81c7-549c" primary="false" name="Heedless Slaughter"/>
       </categoryLinks>
+      <modifiers>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="f479-3c81-1e42-1b3a" field="category"/>
+        <modifier type="add" value="f75a-d5c1-59ba-5c5a" field="category"/>
+        <modifier type="add" value="aa94-5c65-d1f1-46a4" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Cor’bax Utterblight Unbound" hidden="false" id="ef9d-3ad6-1f39-b84b" publicationId="8775-88f5-cfdd-24f6" page="20">
       <selectionEntries>
@@ -1906,6 +1962,11 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
             <modifier type="set" field="name" value="Hammer of Wrath (D3+1)"/>
           </modifiers>
         </infoLink>
+        <infoLink name="Bulky (X)" hidden="false" id="c3a7-a039-cb56-f346" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (6)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <rules>
         <rule name="Herald of Pestilence" hidden="false" id="fc29-4aab-e747-e89c" publicationId="8775-88f5-cfdd-24f6" page="20">
@@ -1933,6 +1994,11 @@ Lord of Decay – All units with the Daemon Unit Type and the Ætheric Dominion 
             <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b7db-bf16-47c5-dc05" type="atLeast"/>
           </conditions>
         </modifier>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+        <modifier type="add" value="7d95-f9d1-440a-67bd" field="category"/>
+        <modifier type="add" value="6e0c-29ba-a445-8321" field="category"/>
+        <modifier type="add" value="f75a-d5c1-59ba-5c5a" field="category"/>
+        <modifier type="add" value="aa94-5c65-d1f1-46a4" field="category"/>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Samus Unbound" hidden="false" id="63f0-9b87-6482-87ee" publicationId="8775-88f5-cfdd-24f6" page="21">
@@ -2111,6 +2177,9 @@ The End and the Death – When fighting in a Challenge, successful Invulnerable 
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="e699-d9cd-e68e-46d9" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Ætheric Conduit" hidden="false" id="9c2-edf8-c9bd-ec05">
       <profiles>
@@ -2387,14 +2456,14 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         </profile>
       </profiles>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Behemoth Blade" hidden="false" id="6ede-e07c-24cd-1813">
+    <selectionEntry type="upgrade" import="true" name="Behemoth Blade" hidden="false" id="6ede-e07c-24cd-1813" publicationId="9fab-fea7-a93c-2074" page="174">
       <profiles>
-        <profile name="Behemoth Blade" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="463e-e46-bf6f-c18a" publicationId="8775-88f5-cfdd-24f6" page="24">
+        <profile name="Behemoth Blade" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="463e-e46-bf6f-c18a" publicationId="9fab-fea7-a93c-2074" page="174">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Brutal (3), Sunder, Immaterial Blades (AP1)</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Brutal (3), Sunder, Immaterial Blades (AP1), Lance, Exoshock (5+)</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -2410,6 +2479,12 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <modifier type="set" value="Immaterial Blades (AP1)" field="name"/>
           </modifiers>
         </infoLink>
+        <infoLink name="Exoshock (X)" hidden="false" id="c876-f5b3-79d6-afa3" type="rule" targetId="69ca-318a-b47a-7a3c">
+          <modifiers>
+            <modifier type="set" value="Exoshock (5+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Lance" hidden="false" id="3a61-1410-e6fc-1972" type="rule" targetId="3d6b-9e0b-56f0-8a1e"/>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Immaterial Flame" hidden="false" id="9d38-bbef-bc48-2ac1" collective="true">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="66e4-4610-1d0e-3c25" name="Horus Heresy (Panoptica)" revision="2001" battleScribeVersion="2.03" authorName="Panoptica Development Team (Imported by LeonisAstra)" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+<gameSystem id="66e4-4610-1d0e-3c25" name="Horus Heresy (Panoptica)" revision="2002" battleScribeVersion="2.03" authorName="Panoptica Development Team (Imported by LeonisAstra)" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
   <publications>
     <publication id="e2a4-ac85-1bef-22f5" name="Github" shortName="LeonisAstra/horus-heresy-panoptica" publisherUrl="https://github.com/LeonisAstra/horus-heresy-panoptica/"/>
     <publication id="e77a-823a-da94-16b9" name="Warhammer: The Horus Heresy - Age of Darkness Rulebook" shortName="Main Rules" publicationDate="June 2022"/>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1176,7 +1176,12 @@ Brace - The Reacting unit must make a Morale check. If the Check is failed, the 
 • A model with the Gargantuan Unit Sub-type may attack with all weapons they have in each Shooting Attack they make, including as part of a Reaction.
 • A model with the Gargantuan Unit Sub-type may make Shooting Attacks with Heavy and Ordnance weapons, counts as Stationary even if it moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
 • No model that does not have the Gargantuan Unit Sub-type may join a unit that includes a model with the Gargantuan Unit Sub-type.
-• A model with the Gargantuan Unit Sub-type ignores all effects (both detrimental and beneficial) of all Psychic Powers and cannot be Wounded or affected by any Attack with the Psychic Focus special rule. Weapons with the Force special rule that are used to make Attacks against a model with the Gargantuan Unit Sub-type are not affected and are resolved normally.</description>
+• A model with the Gargantuan Unit Sub-type ignores all effects (both detrimental and beneficial) of all Psychic Powers and cannot be Wounded or affected by any Attack with the Psychic Focus special rule. Weapons with the Force special rule that are used to make Attacks against a model with the Gargantuan Unit Sub-type are not affected and are resolved normally.
+• Any unit entirely composed of models with the Gargantuan Unit Type
+may choose to ignore the Heroic Stand Special Rule, ignoring any
+penalties normally applied for declining a Challenge, unless the
+Challenge was issued by a model with the Knight, Gargantuan, Titan,
+Primarch, or Daemon Primarch Unit Types.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -1245,7 +1250,10 @@ Brace - The Reacting unit must make a Morale check. If the Check is failed, the 
     <categoryEntry id="a443-dbf4-cb6c-4da1" name="Corrupted Engine Sub-type" hidden="false">
       <rules>
         <rule id="6aed-6080-ba72-6007" name="Corrupted Engine Sub-type" publicationId="6bcf-2297-2bcd-51be" page="8" hidden="false">
-          <description>• All models with the Corrupted Engine Sub-type gain the Fear (1) special rule, or if it already has the Fear (X) special rule, it increases the value of X by 1 instead.
+          <description>An army that uses the Cohort Doctrine (Iron Pattern Cohort) may take a single unit with the Corrupted Engine Unit Sub-type. An army can only include a maximum of one unit with the Corrupted Engine Unit Sub-type chosen in this manner.
+
+
+• All models with the Corrupted Engine Sub-type gain the Fear (1) special rule, or if it already has the Fear (X) special rule, it increases the value of X by 1 instead.
 • Any rule, effect or modifier that would affect a model with the Corrupted Unit Sub-type also affects a model with the Corrupted Engine Unit Sub-type (e.g., the Anathema Sub-type special rules or the Inexorable special rule).
 • Any unit composed entirely of models with the Corrupted Engine Unit Sub-type is immune to the effects of the Fear (X) special rule, automatically passes Regroup tests and cannot choose to fail a Morale check due to the Our Weapons Are Useless special rule. When a unit composed entirely of models with the Corrupted Engine Unit Sub-type fails a Morale check, it does not Fall Back as per the standard rules, but instead suffers D3 automatic Wounds with no saves or Damage Mitigation rolls of any kind allowed.
 • Any Hits inflicted on a model with the Corrupted Engine Unit Sub-type by a weapon with the Force or Psychic Focus special rules gain the Instant Death special rule.
@@ -5259,7 +5267,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
       <profiles>
         <profile id="102e-3487-6e68-51e2" name="Krak Grenades" publicationId="a716-c1c4-7b26-8424" page="143" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The controlling player may choose to have a model with krak grenades that is Engaged or otherwise in base contact during the Assault phase with a Building or Fortification, or a model with the Vehicle, Dreadnought or Automata Unit Type, inflict one automatic Str 6, AP 3 Hit on the target in Initiative Step 1 instead of attacking normally. Any model in a unit that is chosen to inflict Hits using krak grenades may not otherwise attack or make use of any other special rule or item of Wargear that inflicts Hits or Wounds on a model in the same Assault phase (but may participate in Sweeping Advances as normal).</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The controlling player may choose to have a model with krak grenades that is Engaged or otherwise in base contact during the Assault phase with a Building or Fortification, or a model with the Vehicle, Dreadnought or Automata Unit Type, inflict one automatic Str 6, AP 4 Hit on the target in Initiative Step 1 instead of attacking normally. Any model in a unit that is chosen to inflict Hits using krak grenades may not otherwise attack or make use of any other special rule or item of Wargear that inflicts Hits or Wounds on a model in the same Assault phase (but may participate in Sweeping Advances as normal).</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7526,23 +7534,16 @@ A unit that makes a Shooting Attack as part of a Scornful Fire Reaction may not 
       </constraints>
       <rules>
         <rule id="bd1e-ded3-8252-561d" name="Paragon of Metal" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
-          <description>Only one model in an army may be upgraded to have the Paragon of Metal special rule. Models upgraded with the Paragon of Metal special rule must have the Automata (Cybernetica) Unit Type before the upgrade is applied. This rule confers the Paragon Sub-type, which replaces the Cybernetica Unit Sub-type, and confers the It Will Not Die (4+), Precision Strikes (4+), Precision Shots (4+) and Rampage (2) special rules. A model upgraded with the Paragon of Metal special rule also increases both their starting Wounds Characteristic and their Weapon Skill Characteristic by +1.
+          <description>Only one model in an army may be upgraded to have the Paragon of Metal special rule. Models upgraded with the Paragon of Metal special rule must have the Automata (Cybernetica) Unit Type before the upgrade is applied. This rule confers the Paragon Sub-type, which replaces the Cybernetica Unit Sub-type, and confers the It Will Not Die (4+), Precision Strikes (4+), Precision Shots (4+) and Rampage (2) special rules. A model upgraded with the Paragon of Metal special rule also increases both their starting Wounds Characteristic and their Weapon Skill Characteristic by +1. A model which has this Special Rule changes their Armour Save to 2+.
 In addition, a model with the Paragon of Metal special rule may not be targeted or affected by any Cybertheurgic Power or any Weapon with the Data-djinn special rule, either friendly or enemy.</description>
         </rule>
-        <rule id="aa64-ebfc-e457-1e0d" name="Paragon Unit Sub-type" publicationId="bde1-6db1-163b-3b76" page="91" hidden="false">
+        <rule id="aa64-ebfc-e457-1e0d" name="Paragon Unit Sub-type" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
           <description>The following rules apply to all models with the Paragon Unit Sub-type:
 • Models with the Paragon Unit Sub-type are not affected by special rules that negatively modify their Characteristics (other than Wounds or Hull Points).
 • A model with the Paragon Unit Sub-type may fire all weapons they are equipped with in each Shooting Attack they make, including as part of a Reaction.
 • Models with the Paragon Unit Sub-type may fire Heavy and Ordnance weapons and count as Stationary even if they moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
 • A unit that contains a model with the Paragon Unit Sub-type may never be joined by any other models, regardless of any other special rule.
-
-
-From December 2023 Liber Mechanicum FAQ, page 2:
-
-
-Q. Can a unit with the Paragon Unit Sub-type
-make Reactions?
-A. No.</description>
+• In contravention to the GW FAQ, a unit with the Paragon Sub-type may make Reactions, ignoring restrictions from any Unit Type or Sub-type that would prevent it from doing so, as long as the Controlling Player has Reaction allotment available.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -15864,10 +15865,22 @@ Assault Phase).
       <description>When destroyed, a model with this special rule resolves Catastrophic Damage at AP 2</description>
     </rule>
     <rule id="1f93-c765-f7b2-a025" name="Destructor" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
-      <description>Any model which suffers an unsaved Wound or Hull Point loss from a weapon with this special rule instead suffers D6 unsaved Wounds or Hull Points of damage. In addition, if the target of this attack is a model with the Knight, Titan, Super-heavy Vehicle, or Building or Fortification Unit Type, or the Monstrous Unit Sub-type, increase the number of Wounds suffered or Hull Points lost to 2D6.</description>
+      <description>When a model is allocated a Wound or Hull Point Loss inflicted by a weapon with this Special Rule, it does not suffer only one Wound or Hull Point of damage, but instead suffers D6 Wounds or Hull Points of damage instead, with all of the Wounds or Hull Points inflicted using the same AP and special rules as that of the initial Wound. Roll to save against each Wound or Hull Point of damage inflicted separately, but note that Wounds or Hull Points of damage caused in excess of a given model’s remaining Wounds or Hull Points do not spill over to other models and are lost.
+
+
+In addition, if the target of this attack is a model with the Knight, Titan, Gargantuan, Super-Heavy Vehicle, or Building or Fortification Unit Type, or the Monstrous Unit Sub-type, increase the number of Wounds suffered or Hull Points lost to 2D6.</description>
     </rule>
     <rule id="4eb9-9e5e-bb27-3644" name="Disruption (X)" publicationId="bde1-6db1-163b-3b76" page="103" hidden="false">
-      <description>To Hit rolls of the value X indicated made by a weapon with this rule cause an automatic Glancing Hit against models with the Vehicle Unit Type instead of rolling for Armour Penetration, and an automatic Wound against models with the Dreadnought or Automata Unit Types, instead of rolling To Wound.</description>
+      <description>To Hit rolls of the value X indicated made by a weapon with this Special Rule cause an automatic Glancing Hit against models with the Vehicle Unit Type instead of rolling for Armour Penetration, and an automatic Wound against models with the Dreadnought, Automata, or Armiger Unit Types, instead of rolling To Wound.
+
+
+On weapons which do not roll to Hit, such as Template or Blast Weapons, a D6 should be rolled for every applicable target - a roll of X or higher causes an automatic Glancing Hit against models with the Vehicle Unit Type instead of rolling for Armour Penetration, and an automatic Wound against models with the Dreadnought, Automata, or Armiger Unit Types.
+
+
+Only Invulnerable Saves or Damage Mitigation rolls may be taken against Wounds or Hull Points of damage inflicted automatically by this Special Rule.
+
+
+If a model armed with a weapon with this Special Rule receives a Ballistic Skill modifier (such as Night Fighting or being forced to make Snap Shots, etc), then they may only gain the benefit of the Disruption (X) Special Rule on a successful Hit (provided the Hit Roll is equal to or better than the value X).</description>
     </rule>
     <rule id="1cc2-eaee-8bcf-96d3" name="Grav Wave" publicationId="bde1-6db1-163b-3b76" page="104" hidden="false">
       <description>Any successful Charge that targets a unit containing a model with a weapon with this special rule is always counted as a Disordered Charge.</description>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1228,7 +1228,7 @@ Primarch, or Daemon Primarch Unit Types.</description>
 • Failed To Wound rolls, made for weapons with the Armourbane (X) special rule, and against a unit that includes any models with this Unit Sub-type must be re-rolled.
 • A model with the Mechanised Unit Sub-type may attack with all weapons it has when making a Shooting Attack, including as part of a Reaction.
 • A model with the Mechanised Unit Sub-type may attack with Heavy and Ordnance weapons while counting as stationary even if it has moved in the preceding Movement phase, and may declare Charges as normal regardless of any Shooting Attacks made in the same turn.
-• A model with the Mechanised Unit Sub-type is affected by the Haywire, Detonation and Battlesmith (X) special rules as if it had the Dreadnought Unit Type.
+• Any attacks made against a unit with the Mechanised Unit Sub-type are resolved as if the model had the Dreadnought Unit Type, for the purposes of resolving these attacks. Note that this affects any Wargear, Weapons, Special Rules, Psychic Powers, or any other abilities.
 • No model that does not also have the Mechanised Unit Sub‑type may join a unit that includes one or more models with the Mechanised Unit Sub-type.</description>
         </rule>
       </rules>
@@ -1744,7 +1744,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
         </categoryLink>
         <categoryLink id="1ef7-5f17-ade4-e6c1" name="Clanfolk Cavalry (Troops)" hidden="false" targetId="d029-ac65-0ade-0c32" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="369a-4e2e-f7c8-5941" type="max"/>
+            <constraint field="selections" scope="force" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="369a-4e2e-f7c8-5941" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="a360-c557-9119-a286" name="Ogryn Conscripts (Compulsory)" hidden="false" targetId="d813-b3e9-24f0-78bd" primary="false">
@@ -1965,7 +1965,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
         <categoryLink id="13d3-d01e-f52f-e687" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="c1eb-5ad0-5c14-b414" name="Clanfolk Cavalry (Troops)" hidden="false" targetId="d029-ac65-0ade-0c32" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b40d-bc3b-2e1b-1243" type="max"/>
+            <constraint field="selections" scope="force" value="4" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b40d-bc3b-2e1b-1243" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e7a0-a7e0-e7b8-8578" name="Ogryn Conscripts (Compulsory)" hidden="false" targetId="d813-b3e9-24f0-78bd" primary="false">
@@ -2220,7 +2220,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
         </categoryLink>
         <categoryLink id="2b19-38ad-1275-ddd4" name="Clanfolk Cavalry (Troops)" hidden="false" targetId="d029-ac65-0ade-0c32" primary="false">
           <constraints>
-            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b039-28cb-fcb1-592b" type="max"/>
+            <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b039-28cb-fcb1-592b" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="7d46-361b-5baf-f109" name="Ogryn Conscripts (Compulsory)" hidden="false" targetId="d813-b3e9-24f0-78bd" primary="false">
@@ -9825,10 +9825,26 @@ Note that this is an exception to the normal rules for Fortifications, and if as
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 5</characteristic>
           </characteristics>
         </profile>
+        <profile name="Ripper Gun&apos;s Bayonet" hidden="false" id="1342-81ab-9617-fcf2" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" publicationId="9fab-fea7-a93c-2074" page="177">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">5</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Reaping Blow (1), Two-Handed</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Reaping Blow (X)" hidden="false" id="73c8-a129-1a6-d354" type="rule" targetId="bd8c-4f52-d682-1b40">
+          <modifiers>
+            <modifier type="set" value="Reaping Blow (1)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Two-handed" hidden="false" id="70a5-f834-db76-1830" type="rule" targetId="4c23-e863-a569-7617"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="bbc4-b218-ade0-80a1" name="Thunderstub" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
@@ -14636,8 +14652,8 @@ For the purposes of Movement, Shooting Attacks, and Charges, a model deployed v
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e24f-3621-d68e-3cb1" type="max"/>
           </constraints>
           <rules>
-            <rule id="e36c-1974-5c74-ccc6" name="Legacy of the Great Crusade" publicationId="48c2-d023-0069-001a" page="9" hidden="false">
-              <description>All Imperialis Militia Grenadier Squad, Imperialis Militia Command Cadres, and Discipline Masters in a Detachment with this Provenance increase their Ballistic Skill by +1 (to a maximum of 4). A Force Commander in a Detachment with this Provenance increases its Initiative to 5.</description>
+            <rule id="e36c-1974-5c74-ccc6" name="Legacy of the Great Crusade" publicationId="9fab-fea7-a93c-2074" page="152" hidden="false">
+              <description>All Imperialis Militia Grenadier Squad, Imperialis Militia Command Cadres, and units that contain a Discipline Master or Mounted Discipline Master in a Detachment with this Provenance increase their Ballistic Skill by +1 (to a maximum of 4). A Force Commander in a Detachment with this Provenance increases its Initiative to 5.</description>
             </rule>
           </rules>
           <costs>
@@ -14650,8 +14666,8 @@ For the purposes of Movement, Shooting Attacks, and Charges, a model deployed v
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbed-3131-a2c8-ab64" type="max"/>
           </constraints>
           <rules>
-            <rule id="8d20-f35d-f6d9-1186" name="Clanfolk Levy" publicationId="48c2-d023-0069-001a" page="9" hidden="false">
-              <description>A Detachment with this Provenance may choose to fill Compulsory Troops choices only with Imperialis Militia Cavalry Squads, with all models in Imperialis Militia Cavalry Squads selected as Compulsory Troops choices gaining a bonus of +1 to their Leadership Characteristic (this does not allow Imperialis Militia Cavalry Squads to be selected as non-Compulsory Troops choices). In addition, a Detachment with this Provenance may include four additional Fast Attack choices – but these additional choices may only be used to select Imperialis Militia Cavalry Squads.</description>
+            <rule id="8d20-f35d-f6d9-1186" name="Clanfolk Levy" publicationId="9fab-fea7-a93c-2074" page="152" hidden="false">
+              <description>A Detachment with this Provenance may choose to fill Compulsory Troops choices only with Imperialis Militia Cavalry Squads. In addition, all models in Imperialis Militia Cavalry Squads gain a bonus of +1 to their Leadership Characteristic. In addition, a Detachment with this Provenance may include four additional Fast Attack choices – but these additional choices may only be used to select Imperialis Militia Cavalry Squads.</description>
             </rule>
           </rules>
           <costs>
@@ -14740,8 +14756,8 @@ BS NOTE (This Provenance cannot be taken in conjunction with the Cyber-augment o
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34cf-0bac-d780-299a" type="max"/>
           </constraints>
           <rules>
-            <rule id="2b3e-1985-202a-b31f" name="Cyber-augmetics" publicationId="48c2-d023-0069-001a" page="10" hidden="false">
-              <description>All eligible units and models gain the Feel No Pain (6+) and Slow and Purposeful special rules. This Provenance may not be chosen in conjunction with the Gene-crafted Provenance and any Detachment with this Provenance is treated as Sworn Brothers by any Detachment with the Mechanicum Faction in the same army.</description>
+            <rule id="2b3e-1985-202a-b31f" name="Cyber-augmetics" publicationId="9fab-fea7-a93c-2074" page="152" hidden="false">
+              <description>All eligible units and models gain the Feel No Pain (6+) Special Rule, and any eligible unit may be given the Slow and Purposeful Special Rule at no additional points cost. This Provenance may not be chosen in conjunction with the Gene-crafted Provenance and any Detachment with this Provenance is treated as Sworn Brothers by any Detachment with the Mechanicum Faction in the same army.</description>
             </rule>
           </rules>
           <infoLinks>
@@ -14863,8 +14879,8 @@ Option – Chainaxes: Any model eligible to benefit from this Provenance may upg
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d59-f3d7-3290-1e26" type="max"/>
           </constraints>
           <rules>
-            <rule id="ddaa-0389-1b2e-89ae" name="Kinfolk Helots" publicationId="48c2-d023-0069-001a" page="11" hidden="false">
-              <description>All eligible units and models receive an increase of +1 to their Toughness Characteristic but also lower their Initiative and Movement Characteristics by -1 (to a minimum of 1, models with a Movement of 0 or - are not affected and remain Movement 0 or -). All eligible models in a Detachment with this Provenance and the Character Unit Sub-type gain the Battlesmith (6+) special rule, or if they also have the Independent Character special rule gain the Battlesmith (5+) special rule instead. This Provenance may not be chosen in conjunction with the Ogryn Conscripts Provenance.</description>
+            <rule id="ddaa-0389-1b2e-89ae" name="Kinfolk Helots" publicationId="9fab-fea7-a93c-2074" page="152" hidden="false">
+              <description>All eligible units and models change their Toughness Characteristic to be one higher than its starting value (a Toughness characteristic of 3 being changed to 4 on their statline, for example), but also change their Initiative and Movement Characteristics to be one lower than its starting value (in the same way as above). All eligible models in a Detachment with this Provenance and the Character Unit Sub-type gain the Battlesmith (6+) Special Rule, or if they also have the Independent Character Special Rule gain the Battlesmith (5+) Special Rule instead. This Provenance may not be chosen in conjunction with the Ogryn Conscripts Provenance.</description>
             </rule>
           </rules>
           <costs>
@@ -14884,8 +14900,8 @@ Option – Chainaxes: Any model eligible to benefit from this Provenance may upg
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb11-ba20-4ab6-86c6" type="max"/>
           </constraints>
           <rules>
-            <rule id="b726-7fd3-991b-4752" name="Abhuman Muster" publicationId="48c2-d023-0069-001a" page="11" hidden="false">
-              <description>All eligible units and models receive an increase of +1 to their Strength Characteristic but also lower their Ballistic Skill by -1 (to a minimum of 1) and, if they do not already possess any variant of the Bulky (X) special rule, gain the Bulky (2) special rule. All eligible models in a Detachment with this Provenance and the Character Unit Sub-type gain the Hammer of Wrath (1) special rule, or if they also have the Independent Character special rule or the Monstrous Unit Sub-type gain the Hammer of Wrath (2) special rule instead. This Provenance may not be chosen in conjunction with the Ogryn Conscripts Provenance.</description>
+            <rule id="b726-7fd3-991b-4752" name="Abhuman Muster" publicationId="9fab-fea7-a93c-2074" page="152" hidden="false">
+              <description>All eligible units and models change their Strength and Movement Characteristic to be one higher than its starting value (a Strength characteristic of 3 being changed to 4 on their statline, for example), but also change their Ballistic Skill Characteristic to be one lower than its starting value (in the same way as above) and, if they do not already possess any variant of the Bulky (X) Special Rule, gain the Bulky (2) Special Rule. All eligible models in a Detachment with this Provenance gain the Hammer of Wrath (1) Special Rule. If a model also has the Character Unit Sub-type or the Monstrous Unit Sub-type, they gain the Hammer of Wrath (2) Special Rule instead, or +1 to an existing Hammer of Wrath (X) Special Rule if they already have the Hammer of Wrath (2) Special Rule. This Provenance may not be chosen in conjunction with the Ogryn Conscripts Provenance.”</description>
             </rule>
           </rules>
           <costs>
@@ -16047,7 +16063,7 @@ Scatter dice.
 • The penalty to Leadership is ignored by any unit with the Fearless or Stubborn special rules. A Primarch unit, or any unit with the Night Vision special rule ignores both the penalties to Leadership and Ballistic Skill and the restrictions on drawing line of sight to other units.
 • Note that in some missions, if the Player with Strategic Advantage elects to not activate Night Fighting, the Opposing Player may still have the Night Fighting Rules in effect on a roll of a 4+.</description>
     </rule>
-    <rule id="1cb6-d7f2-0c79-d208" name="Ungainly" publicationId="48c2-d023-0069-001a" page="41" hidden="false">
+    <rule id="1cb6-d7f2-0c79-d208" name="Ungainly" publicationId="9fab-fea7-a93c-2074" page="154" hidden="false">
       <description>A model may only attack with this weapon on a turn in which it makes a Charge (even if that Charge is Disordered), but does not gain a bonus attack for Charging or from any Special Rules that would normally grant additional Attacks.</description>
     </rule>
     <rule id="2dfc-b3cc-7ede-2827" name="Impale" publicationId="6bcf-2297-2bcd-51be" page="15" hidden="false">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -10725,6 +10725,55 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Praetor Launcher" hidden="false" id="c123-e9f7-ee20-c4f9" collective="false" publicationId="9fab-fea7-a93c-2074" page="170">
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="629a-cc77-d839-28f4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ff80-42b5-635d-c91" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+      </constraints>
+      <profiles>
+        <profile name="Praetor Launcher - Firestorm" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="152e-7733-d4ae-b642" publicationId="9fab-fea7-a93c-2074" page="170">
+          <characteristics>
+            <characteristic name="Range" hidden="false" id="f49-866f-ee5d-93d8" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" hidden="false" id="39fb-bc6d-9987-67b5" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" hidden="false" id="dbab-2ec6-6db1-6882" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" hidden="false" id="a1d7-e525-6d26-4b60" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 2, Barrage, Massive Blast (7&quot;), Pinning, Shell Shock (2), Rending (5+), Ignores Cover</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Praetor Launcher - Foehammer" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="5e6f-403d-95ab-3e4c" publicationId="9fab-fea7-a93c-2074" page="170">
+          <characteristics>
+            <characteristic name="Range" hidden="false" id="7258-6a05-4321-c3d5" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Strength" hidden="false" id="f1a0-854a-a086-8f59" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" hidden="false" id="ade2-a2fd-7140-74f2" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" hidden="false" id="fc-ee77-cc0d-1a5b" typeId="2f86-c8b4-b3b4-3ff9">Heavy 12, Guided Fire, Breaching (5+), Ignores Cover</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Rending (X)" hidden="false" id="ea5e-314e-5b6-d8a7" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" value="Rending (5+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Blast" hidden="false" id="ae30-bb54-6c9d-560b" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
+        <infoLink name="Pinning" hidden="false" id="85f2-bc0b-63d5-66dc" targetId="1c96-205c-59a0-3cf2" type="rule"/>
+        <infoLink name="Barrage" hidden="false" id="c2d9-1bb9-32f-8fdb" targetId="7255-b5ee-c3f4-3037" type="rule"/>
+        <infoLink name="Breaching (X)" hidden="false" id="49c9-b86f-eeac-f9a8" targetId="a760-f736-1bf3-fa3c" type="rule">
+          <modifiers>
+            <modifier type="set" value="Breaching (5+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Ignores Cover" hidden="false" id="6a0b-ebc3-5d28-e1c8" type="rule" targetId="fdb5-59e2-c446-1cbc"/>
+        <infoLink name="Shell Shock (X)" hidden="false" id="c7c7-d186-99b8-6c1e" targetId="46b7-63a1-941c-96a5" type="rule">
+          <modifiers>
+            <modifier type="set" value="Shell Shock (2)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Guided Fire" hidden="false" id="a625-1de4-2467-3d8d" type="rule" targetId="fa1e-0112-943e-b1f6"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" hidden="false" id="c724-d5ba-bb13-e6eb" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="4a48-4935-246d-0c2e" name="Legion" hidden="false" collective="false" import="true">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -965,13 +965,28 @@ In addition, when a Fast Vehicle moves, it may choose to move at Flat-out:</desc
     <categoryEntry id="d82b-1980-74f8-5dac" name="Allied Detachment" hidden="false"/>
     <categoryEntry id="d615-c0e4-6d17-107e" name="Assassin Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
       <rules>
-        <rule id="9522-1b3d-f849-fd60" name="Assassin Sub-Type" publicationId="15a4-fc68-502d-48a9" page="128" hidden="false">
+        <rule id="9522-1b3d-f849-fd60" name="Assassin Sub-Type" publicationId="9fab-fea7-a93c-2074" page="148" hidden="false">
           <description>• Models with the Assassin Sub-type ignore all movement penalties when moving or Charging through terrain of any kind and automatically pass all Dangerous Terrain tests they are called upon to make.
 • Models with the Independant Character special rule may not join a unit composed only of models with the Assassin Sub-type.
 • Models with the Assassin Sub-type may not Embark on any model with the Transport Sub-type.
-• Modesl with the Assassin Sub-type may never be selected as an army&apos;s Warlord</description>
+• Models with the Assassin Sub-type may never be selected as an army&apos;s Warlord
+• Models with the Assassin Sub-type gain the Precision Shots (2+),
+Precision Strikes (2+), and Predator’s Gaze Special Rule</description>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink name="Precision Shots (X)" hidden="false" id="85d3-81b6-9e35-890c" type="rule" targetId="4b71-81ee-31f4-fa09">
+          <modifiers>
+            <modifier type="set" value="Precision Shots (2+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Precision Strikes (X)" hidden="false" id="10c9-a753-b291-90b9" type="rule" targetId="2206-8497-8fe1-e973">
+          <modifiers>
+            <modifier type="set" value="Precision Strikes (2+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Predator&apos;s Gaze" hidden="false" id="8ef5-4127-7ecf-e0b0" type="rule" targetId="9f34-bb3b-e63b-299a"/>
+      </infoLinks>
     </categoryEntry>
     <categoryEntry id="0af0-ea84-09d7-2b1f" name="Close-order Sub-type" publicationId="15a4-fc68-502d-48a9" page="129" hidden="false">
       <rules>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -1689,7 +1689,7 @@ If a Skimmer is Immobilised or Wrecked, its base is removed, if possible. If thi
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3210-baff-f554-8019" type="max"/>
+            <constraint field="selections" scope="force" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3210-baff-f554-8019" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b095-12d9-ff21-c90b" name="Compulsory HQ:" hidden="false" targetId="f823-8c1d-6a87-26a1" primary="false">

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -3589,7 +3589,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
         <profile id="71e6-ddb0-279a-7101" name="Grenade launcher - Krak (Secondary)" publicationId="a716-c1c4-7b26-8424" page="130" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
           </characteristics>
@@ -5063,7 +5063,7 @@ THIS IS A TEMPORARY NOTIFICATION THAT WILL BE REMOVED IN A FEW MONTHS WHEN HOPEF
     </selectionEntry>
     <selectionEntry id="ff4d-6e1b-7b44-9b72" name="Volkite Macro-Saker" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="f429-67a3-5a34-0d16" name="Volkite Macro-Saker" publicationId="a716-c1c4-7b26-8424" page="134" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+        <profile id="f429-67a3-5a34-0d16" name="Volkite Macro-Saker" publicationId="9fab-fea7-a93c-2074" page="172" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">45&quot;</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
@@ -8053,7 +8053,7 @@ In addition, a model with the Paragon of Metal special rule may not be targeted 
         <infoLink id="8e9f-be33-224b-961b" name="Bolter (Primary)" hidden="false" targetId="ace5-c6fe-e205-07d1" type="profile"/>
         <infoLink id="7761-21ff-412e-6181" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
         <infoLink id="5a4d-9a53-9faf-fbda" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-        <infoLink id="4dc3-e17b-d90a-f373" name="Grenade launcher - Krak (Secondary)" hidden="false" targetId="71e6-ddb0-279a-7101" type="profile"/>
+        <infoLink id="4dc3-e17b-d90a-f373" name="Grenade launcher - Krak (Secondary)" hidden="false" targetId="71e6-ddb0-279a-7101" type="profile" publicationId="9fab-fea7-a93c-2074" page="171"/>
         <infoLink id="beb1-60fd-93a6-0eda" name="Grenade launcher - Frag (Secondary)" hidden="false" targetId="5bff-6214-348d-0536" type="profile"/>
       </infoLinks>
       <costs>
@@ -9536,10 +9536,10 @@ Note that this is an exception to the normal rules for Fortifications, and if as
       <profiles>
         <profile id="c65a-2132-c8cd-1696" name="Stormhammer Cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
-            <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordinance 1, Massive Blast (7&quot;)</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 3, Lance, Exoshock (6+)</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -10772,6 +10772,29 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
       </infoLinks>
       <costs>
         <cost name="Pts" hidden="false" id="c724-d5ba-bb13-e6eb" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="682a-c2bd-16c-db51" name="Exterminator Autocannon" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="170">
+      <profiles>
+        <profile id="68e4-f262-a7f8-a6ca" name="Exterminator Autocannon" publicationId="9fab-fea7-a93c-2074" page="170" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">48&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 6, Rending (5+), Twin-linked</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="a649-b6ba-c967-ef41" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
+          <modifiers>
+            <modifier type="set" field="name" value="Rending (5+)"/>
+          </modifiers>
+        </infoLink>
+        <infoLink id="a662-a610-ab23-f8b4" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -15977,7 +16000,10 @@ Maxima :When destroyed, a model with this special rule resolves Hits caused by C
       <description>A model with this Special Rule must target the closest enemy model as per the following limitations and restrictions:
 - Any model armed with a weapon of Strength 7 or more must target the nearest enemy model with the Vehicle, Automata, or Dreadnought Sub-types.
 - Any model armed with a weapon of Strength 6 or below must target the nearest enemy model without the Vehicle, Automata, or Dreadnought Sub-types.
-- Any model armed with a weapon with the Skyfire Special Rule must target the nearest enemy model with the Flyer Sub-type. If no such target is in range, then the Controlling Player may select a target as normal.</description>
+- Any model armed with a weapon with the Skyfire Special Rule must target the nearest enemy model with the Flyer Sub-type. 
+
+
+If no such target is in range, then the Controlling Player may select a target as normal.</description>
     </rule>
     <rule id="c036-66e2-4e07-c2b8" name="Automated Artillery Sub-type" publicationId="e77a-823a-da94-16b9" page="16" hidden="false">
       <description>The following rules apply to all models with the Automated Artillery Sub-type:
@@ -15996,7 +16022,10 @@ Maxima :When destroyed, a model with this special rule resolves Hits caused by C
       <description>After a model with this special rule (for a unit composed entirely of models with this special rule) has resolved a Shooting Attack targeting an enemy unit, any weapons that were not used to attack (either dur to being out of line of sight or range of the enemy units, or because the controlling player voluntarily opted not to attack with them) may make a number of Secondary Shooting Attacks using those weapons that did not fire as part of its initial Shooting Attack. Each weapon not fired as part of the initial Shooting Attack may be fired once, either all of them in a single Secondary Shooting Attack, each in a separate Secondary Shooting Attack targeting a different enemy unit of any combination - however, each weapon may only be used to attack once and in no more than one Secondary Shooting Attack. All Secondary Shooting Attacks obey all the normal rules for range and line of sight and are with a modifier of -1 on all To Hit rolls.
 
 
-Instead of the above, in a turn in which a model with this Special Rule either remained Stationary or moved at Combat Speed during the Controlling Player’s Movement Phase, then for the duration of the Controlling Player’s following Shooting Phase, it may make Shooting Attacks as if it had the Super Heavy Sub-Type.</description>
+A model with this Special Rule must be assigned to another unit made up entirely of models with the Vehicle Unit Type purchased as part of the same Tercio.
+
+
+In addition, a model with this Special Rule may still make Shooting Attacks as normal in a turn in which they use their Cognis-Signum to provide +1 Ballistic Skill to all other models in their unit, even though this would normally be prevented by using this Wargear.</description>
     </rule>
     <rule id="71fa-da0d-0056-9072" name="Kharash" hidden="false">
       <modifiers>

--- a/2022 - Horus Heresy.gst
+++ b/2022 - Horus Heresy.gst
@@ -10668,6 +10668,47 @@ Once all models in the unit have moved onto the battlefield, the Warp Rift marke
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="bc17-b7a5-deed-7bf7" name="Conversion Destructor" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="171">
+      <profiles>
+        <profile id="d7b-6641-cfc9-ee25" name="Conversion Destructor (1)" publicationId="9fab-fea7-a93c-2074" page="171" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">0 - 18&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Blind</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="317f-716e-29f-5abf" name="Conversion Destructor (2)" publicationId="9fab-fea7-a93c-2074" page="171" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">More Than 18&quot; - 42&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Blind, Sunder</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="fbdf-e4ec-cde9-dab1" name="Conversion Destructor (3)" publicationId="9fab-fea7-a93c-2074" page="171" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="95ba-cda7-b831-6066">More Than 42&quot; - 80&quot;</characteristic>
+            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">12</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Large Blast (5&quot;), Blind, Sunder, Wrecker</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="7f92-1a32-5381-9013" name="Blind" hidden="false" targetId="d836-747d-07d6-2b63" type="rule"/>
+        <infoLink id="649b-adea-25cc-54a6" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule">
+          <modifiers>
+            <modifier type="set" value="Large Blast (5&quot;)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Sunder" hidden="false" id="2f67-ecb7-6552-c6d7" type="rule" targetId="20e2-75cf-bc16-cd8f"/>
+        <infoLink name="Wrecker" hidden="false" id="eb9d-c9ac-f531-2b14" type="rule" targetId="ba77-a802-55df-da67"/>
+      </infoLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="4a48-4935-246d-0c2e" name="Legion" hidden="false" collective="false" import="true">

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f887-2c56-4cb0-2e9c" name="Imperialis Militia" revision="2036" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="f887-2c56-4cb0-2e9c" name="Imperialis Militia" revision="2037" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="58b3-196a-9732-2165" name="Rogue Psyker Daemons Restriction" publicationId="48c2-d023-0069-001a" page="15" hidden="false">
       <modifiers>

--- a/2022 - Imperialis Militia.cat
+++ b/2022 - Imperialis Militia.cat
@@ -13,6 +13,17 @@
         <constraint field="selections" scope="force" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="20f0-fb34-27b7-a811" type="max"/>
       </constraints>
     </categoryEntry>
+    <categoryEntry name="Static Artillery" hidden="false" id="8664-76f2-fe15-751a">
+      <rules>
+        <rule name="Static Artillery" hidden="false" id="246b-d84-9f3f-5576">
+          <description>• A unit that includes one or more models with the Static Artillery Sub-type may never Embark or be Deployed on the battlefield Embarked on a model with the Transport Sub-type and may never benefit from the Scout or Infiltrate special rules.
+• A unit that includes one or more models with the Static Artillery Sub-type may never be placed in Reserves and is counted as destroyed if any rule requires it to be placed into Reserves.
+• A unit that includes one or more models with the Static Artillery Sub-type may not Run, declare or otherwise make Charge moves, or make Reactions.
+• A unit that includes one or more models with the Static Artillery Sub-type may not make Sweeping Advances and if targeted by a Sweeping Advance automatically fails without rolling any dice and is destroyed.
+• A unit that includes one or more models with the Static Artillery Unit Sub-type may never hold or deny an Objective.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
   </categoryEntries>
   <selectionEntries>
     <selectionEntry id="37de-ba3c-f798-5bcb" name="Provenances of War" hidden="false" collective="false" import="false" type="upgrade">
@@ -651,6 +662,16 @@
                 <condition field="selections" scope="b79a-6c4b-cea3-6732" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce01-5fca-9d27-590b" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="add" field="category" value="bff2-ae16-74a8-8712">
+              <conditions>
+                <condition field="selections" scope="b79a-6c4b-cea3-6732" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce01-5fca-9d27-590b" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="59a4-7b61-600a-c457">
+              <conditions>
+                <condition field="selections" scope="b79a-6c4b-cea3-6732" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ce01-5fca-9d27-590b" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99b7-2304-d9fe-3545" type="min"/>
@@ -677,7 +698,7 @@
                   </conditions>
                   <modifiers>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="14"/>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Militia, Character)"/>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Militia, Skirmish, Light, Character)"/>
                     <modifier type="set" field="name" value="Mounted Force Commander"/>
                   </modifiers>
                 </modifierGroup>
@@ -1658,6 +1679,16 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <condition field="selections" scope="d621-f543-cdc5-cdc3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0173-00e3-8593-2e0a" type="equalTo"/>
               </conditions>
             </modifier>
+            <modifier type="add" field="category" value="bff2-ae16-74a8-8712">
+              <conditions>
+                <condition field="selections" scope="d621-f543-cdc5-cdc3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0173-00e3-8593-2e0a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="59a4-7b61-600a-c457">
+              <conditions>
+                <condition field="selections" scope="d621-f543-cdc5-cdc3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0173-00e3-8593-2e0a" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="664c-5e76-1d3d-8263" type="min"/>
@@ -1688,7 +1719,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <condition field="selections" scope="d621-f543-cdc5-cdc3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0173-00e3-8593-2e0a" type="equalTo"/>
                   </conditions>
                   <modifiers>
-                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Militia, Character)"/>
+                    <modifier type="set" field="ddd7-6f5c-a939-b69e" value="Cavalry (Militia, Skirmish, Light, Character)"/>
                     <modifier type="set" field="893e-2d76-8f04-44e5" value="14"/>
                     <modifier type="set" field="name" value="Mounted Discipline Master"/>
                   </modifiers>
@@ -1738,7 +1769,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <description>If a unit that includes a model with this special rule fails a Morale check, a re-roll can be made – if this is done, the unit suffers D3 Wounds at AP -. These Wounds are allocated by the unit’s controlling player, but may not be inflicted on Independent Characters, the Discipline Master themselves or Militia Medicae who have joined the unit.</description>
             </rule>
             <rule id="c4fc-6361-79b1-0c04" name="Among the Ranks" publicationId="48c2-d023-0069-001a" page="13" hidden="false">
-              <description>An Imperialis Militia Discipline Master Cadre is selected like any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins and any models are deployed to the battlefield, all models in an Imperialis Militia Discipline Master Cadre must be assigned to another unit from the same Detachment of the army they were selected as part of. Discipline Masters may only be assigned to units composed entirely of models with the Infantry Unit Type and Militia Unit Sub-type, unless upgraded to a Mounted Discipline Master, in which case that model must be assigned to an Imperialis Militia Cavalry Squad. No more than one Discipline Master may be assigned to any given unit. Once assigned to a unit, the Discipline Master is considered part of that unit and may not leave it under any circumstances – if that unit is removed as a casualty then the Discipline Master is removed as well. In battles using Victory points, no Victory points are ever scored for removing a Discipline Master as a casualty. When assigned to a unit, a Discipline Master gains all of the special rules (with the exception of those that specifically forbid it, such as the Bitter Duty special rule) and Unit Sub-types listed for the unit to which it is attached, but does not gain access to any additional Wargear options available to the unit to which it is assigned.</description>
+              <description>An Imperialis Militia Discipline Master Cadre is selected like any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins and any models are deployed to the battlefield, all models in an Imperialis Militia Discipline Master Cadre must be assigned to another unit from the same Detachment of the army they were selected as part of. Discipline Masters may only be assigned to units composed entirely of models with the Infantry Unit Type, and either the Militia or Artillery Unit Sub-types, unless upgraded to a Mounted Discipline Master, in which case that model must be assigned to a Unit with the Cavalry Unit Type and the Militia Unit Sub-type. No more than one Discipline Master may be assigned to any given unit. Once assigned to a unit, the Discipline Master is considered part of that unit and may not leave it under any circumstances – if that unit is removed as a casualty then the Discipline Master is removed as well. In battles using Victory points, no Victory points are ever scored for removing a Discipline Master as a casualty. When assigned to a unit, a Discipline Master gains all of the special rules (with the exception of those that specifically forbid it, such as the Bitter Duty special rule) and Unit Sub-types listed for the unit to which it is attached, but does not gain access to any additional Wargear options available to the unit to which it is assigned.</description>
             </rule>
           </rules>
           <infoLinks>
@@ -2618,7 +2649,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="b6a8-c9a1-617c-44e3" name="1.4) One Militia bodyguard Special Weapon:" hidden="true" collective="false" import="true">
+            <selectionEntryGroup id="b6a8-c9a1-617c-44e3" name="1.4) One in every 5 Militia Bodyguards&apos; Special Weapon:" hidden="true" collective="false" import="true">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -2628,7 +2659,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6185-2ce4-de63-c9a2" type="max"/>
-                <constraint field="selections" scope="b179-24bb-a4b0-3eb4" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbeb-ca9a-2f61-e78f" type="max"/>
+                <constraint field="selections" scope="b179-24bb-a4b0-3eb4" value="27" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="bbeb-ca9a-2f61-e78f" type="max">
+                  <comment>Panoptica 16</comment>
+                </constraint>
               </constraints>
               <entryLinks>
                 <entryLink id="19b8-9496-4df2-1134" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
@@ -2663,7 +2696,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
                 <entryLink id="b568-2222-fb59-33bb" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="f0d1-332b-c719-ede7" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
                 <entryLink id="48eb-3594-90d3-334d" name="Needle Vulnus" hidden="true" collective="false" import="true" targetId="69b0-3b27-e0fc-c87c" type="selectionEntry">
@@ -2739,7 +2772,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
           </costs>
           <categoryLinks>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2d74-1fc2-43ec-963d" name="Infantry Unit Type" primary="false"/>
@@ -2837,7 +2870,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <entryLink id="ee8a-3d77-b3fc-8f04" name="Provenance Options" hidden="false" collective="false" import="true" targetId="5fb4-282e-7957-1492" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="13"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b4a8-0824-b604-3277" name="IM - Infantry Squad" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
@@ -4612,7 +4645,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="d90e-7a74-30df-097a" name="1.4) Two Grenadiers may exchange their Lasgun for:" hidden="true" collective="false" import="true">
+            <selectionEntryGroup id="d90e-7a74-30df-097a" name="1.4) Two in Ten Grenadiers may exchange their Lasgun for:" hidden="true" collective="false" import="true" publicationId="9fab-fea7-a93c-2074" page="153">
               <modifiers>
                 <modifier type="set" field="hidden" value="false">
                   <conditions>
@@ -4622,7 +4655,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4576-af17-1096-2ce3" type="max"/>
-                <constraint field="selections" scope="c201-6fbc-a792-0509" value="2" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bab9-fe08-802e-2d96" type="max"/>
+                <constraint field="selections" scope="c201-6fbc-a792-0509" value="22" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="bab9-fe08-802e-2d96" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="8e31-6e10-a126-4db1" name="Heavy Stubber" hidden="false" collective="false" import="true" targetId="f227-a61a-3215-932b" type="selectionEntry">
@@ -5224,6 +5257,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <infoLinks>
                 <infoLink id="d534-6ca0-d86b-4d03" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="4098-3c22-904d-c447" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="fd4e-8de6-1217-84bd" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="d400-1fc6-705c-d90f" name="Lascannon" hidden="false" collective="false" import="true" targetId="8621-4e12-b3d2-116f" type="selectionEntry">
@@ -5237,12 +5271,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5537-0c68-4499-972c" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="868b-2ec9-4231-a6e0" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="2a09-7ca6-43fa-879a" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="b9f7-16a4-56e6-9618" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="9643-3e33-55ed-e9f1" name="Militia Fire Team w/ Autocannon" hidden="false" collective="false" import="true" type="model">
@@ -5252,6 +5287,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <infoLinks>
                 <infoLink id="90d3-251a-c9d8-5e01" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="9f72-c31f-e78a-11fd" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="62f1-7052-2bff-3922" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="3fed-1097-9a48-9309" name="Autocannon" hidden="false" collective="true" import="true" type="upgrade">
@@ -5281,12 +5317,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="2b1f-3565-4790-861f" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="95c8-b9f1-4ebd-93fe" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="ba52-9558-49bd-b8ac" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e60c-a52f-2d59-b9ae" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ff1-5b17-ca8b-0676" name="Militia Fire Team w/ Heavy Stubber" hidden="false" collective="false" import="true" type="model">
@@ -5329,7 +5366,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     </modifierGroup>
                   </modifierGroups>
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Militia)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Militia, Skirmish)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
@@ -5345,6 +5382,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               </profiles>
               <infoLinks>
                 <infoLink id="47cd-75e6-5980-be11" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="5d05-51c3-cdb5-2c80" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="b708-9e31-03af-c9c9" name="Heavy Stubber" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="true" import="true" type="upgrade">
@@ -5369,24 +5407,26 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="5a1d-95f6-4db4-8836" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="5dcb-25b5-487b-9ebc" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="eb2f-8d44-4b2d-9e59" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="a2c1-d851-3b7-a46e" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
-            <selectionEntry id="ffb6-7ae4-9f04-7c7d" name="Militia Fire Team w/ Missile Launcher Frag/Krak" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="ffb6-7ae4-9f04-7c7d" name="Militia Fire Team w/ Missile Launcher Frag/Krak/Flak" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e23-e2ff-b69b-193a" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3fc5-d586-6a97-069d" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="0df7-197e-d848-00be" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="502d-e094-3471-3de0" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <selectionEntries>
-                <selectionEntry id="9426-c270-d276-0d3b" name="Missile Launcher w/Frag &amp; Krak Missiles" hidden="false" collective="true" import="true" type="upgrade">
+                <selectionEntry id="9426-c270-d276-0d3b" name="Missile Launcher w/ Frag/Krak/Flak Missiles" hidden="false" collective="true" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c95a-ddfa-df42-fd9b" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e48-3572-4603-646e" type="max"/>
@@ -5394,6 +5434,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                   <entryLinks>
                     <entryLink id="ed51-b42e-16d1-fdb7" name="Missile Launcher - Krak" hidden="false" collective="false" import="true" targetId="9672-5a76-2b33-b481" type="selectionEntry"/>
                     <entryLink id="2b65-42b8-ec99-1db0" name="Missile Launcher - Frag" hidden="false" collective="false" import="true" targetId="44d5-b79c-b828-a8b1" type="selectionEntry"/>
+                    <entryLink id="522e-526e-1ca4-6d10" name="Missile Launcher - Flak" hidden="false" collective="false" import="true" targetId="0da1-3e1d-c05b-b828" type="selectionEntry"/>
                   </entryLinks>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
@@ -5409,12 +5450,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="53cf-4e7c-4b0f-b16e" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="3dc5-e564-4ef9-a4d5" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="d5c5-5d8f-44f3-8425" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="77b0-3db9-6048-f8a8" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="237e-5215-928f-a38f" name="Militia Fire Team w/ Mortar" hidden="false" collective="false" import="true" type="model">
@@ -5424,6 +5466,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <infoLinks>
                 <infoLink id="0730-9cb8-9ab9-243a" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="fc27-815b-2b49-6593" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="4630-e3d2-c51a-3d05" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="70b6-3904-a1fd-3d55" name="Mortar" hidden="false" collective="true" import="true" type="upgrade">
@@ -5451,12 +5494,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="6849-022b-4f86-a5dc" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="1212-8194-4301-a810" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="6f7d-c4dd-45b1-8de0" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="8181-b9df-e78-e65a" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="e5fc-9d18-110f-569b" name="Militia Fire Team w/ Multilaser" hidden="false" collective="false" import="true" type="model">
@@ -5466,6 +5510,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <infoLinks>
                 <infoLink id="8afe-269b-9687-10b8" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="cf21-01eb-f09b-2e78" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="f36f-a6c3-e7c7-74db" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <selectionEntries>
                 <selectionEntry id="debb-5e09-f077-80eb" name="Multi-Laser" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="true" import="true" type="upgrade">
@@ -5490,12 +5535,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7d70-7d41-41d5-963e" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="45ad-fe95-48c7-985a" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="150c-1f22-47ce-8335" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="3d5-88ce-4138-821d" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="0170-77fa-0994-bbe7" name="Militia Fire Team w/ Heavy Bolter" hidden="false" collective="false" import="true" type="model">
@@ -5505,6 +5551,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <infoLinks>
                 <infoLink id="820b-7bd3-c3b3-1294" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
                 <infoLink id="3559-a290-e199-cd6d" name="Militia Fire Team" hidden="false" targetId="03bb-2121-1d1b-4555" type="profile"/>
+                <infoLink name="Crew-Served Weapon" hidden="false" id="90d1-ec0e-490a-c83a" type="rule" targetId="130b-ba36-a77d-15ed"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="dc01-5da5-9f58-7bb2" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -5524,12 +5571,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="7758-9588-4f1e-9fd7" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="d928-1eac-4c4d-90b5" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="b2b2-2c94-439e-bc1c" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e027-8cfb-3152-c6e1" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -5539,7 +5587,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <entryLink id="7205-3850-19d2-ec2f" name="Provenance Options" hidden="false" collective="false" import="true" targetId="5fb4-282e-7957-1492" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a90-6dc5-1e0b-9eaf" name="IM - Reconnaissance Squad" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
@@ -5665,7 +5713,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Light)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Skirmish, Light)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
@@ -5686,6 +5734,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b33e-d51f-4da5-b29d" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="66b2-c457-4d5e-8041" id="ee74-71a4-4846-8a2c" name="Militia Unit Sub-type" primary="false"/>
             <categoryLink targetId="bff2-ae16-74a8-8712" id="20d5-00e8-4d40-9d8e" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="1b91-73fb-4d17-af60" primary="false" name="Skirmish Sub-type:"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry id="73bd-73fb-8c08-283b" name="Scout Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -5729,7 +5778,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Light, Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Light, Skirmish, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
@@ -5770,6 +5819,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4ea9-82e2-4394-936b" name="Infantry Unit Type" primary="false"/>
             <categoryLink targetId="66b2-c457-4d5e-8041" id="9f81-b7f4-4619-ade9" name="Militia Unit Sub-type" primary="false"/>
             <categoryLink targetId="bff2-ae16-74a8-8712" id="d5b1-ff57-4159-8820" name="Light Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="94b3-124f-46d3-dbb9" primary="false" name="Skirmish Sub-type:"/>
           </categoryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -5860,10 +5910,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="bfa4-d7c9-0db4-ab26" name="4) Up to 5 models per unit may exchange their shotguns, lascarbines or stubcarbines for:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b155-2415-5d6c-b26a" type="max"/>
-          </constraints>
+        <selectionEntryGroup id="bfa4-d7c9-0db4-ab26" name="4) Any model may exchange their shotguns, lascarbines or stubcarbines for:" hidden="false" collective="false" import="true">
           <entryLinks>
             <entryLink id="e723-57e7-a1d3-f0d9" name="Longlas" hidden="false" collective="false" import="true" targetId="4f84-24fa-70bb-0788" type="selectionEntry">
               <modifiers>
@@ -6015,6 +6062,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="c254-7761-dbf3-9329" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
         <categoryLink id="6748-d0c8-4f36-f942" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="1287-bd1c-809-f3e3" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="c239-2015-9480-1aec" primary="false" name="Skirmish Sub-type:"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="2240-7d3b-fa8c-63b8" name="2) Armour" hidden="false" collective="false" import="true" defaultSelectionEntryId="1147-882e-bd83-ed0a">
@@ -6086,7 +6134,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     </modifierGroup>
                   </modifierGroups>
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Militia)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Skirmish, Militia)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">4</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
@@ -6109,7 +6157,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <infoLink id="44a5-ed8b-4ab7-4d75" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
               </infoLinks>
               <selectionEntries>
-                <selectionEntry id="6472-4131-dbfe-14a2" name="Heavy Lascannon" publicationId="48c2-d023-0069-001a" hidden="false" collective="true" import="true" type="upgrade">
+                <selectionEntry id="6472-4131-dbfe-14a2" name="Heavy Lascannon" publicationId="9fab-fea7-a93c-2074" hidden="false" collective="true" import="true" type="upgrade" page="153">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8049-43b0-dbef-eaba" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd75-b5d1-e78c-bfb3" type="max"/>
@@ -6119,7 +6167,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <infoLink id="8d26-81bb-57f6-9b0b" name="Heavy Lascannon" hidden="false" targetId="a911-f050-1265-8967" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -6130,6 +6178,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="298a-0b27-4850-9852" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="cc2f-af5d-4690-8887" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="3b4b-3e9c-4821-af75" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="2fb6-33ae-f7ae-c8f2" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="5ea0-e933-72fe-17a5" name="Militia Field Gun w/ Kalliope Mortar" hidden="false" collective="false" import="true" type="model">
@@ -6146,7 +6195,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <infoLink id="ad0d-c95e-376c-0b8a" name="Emplaced" hidden="false" targetId="976f-9e14-413c-5bea" type="rule"/>
               </infoLinks>
               <selectionEntries>
-                <selectionEntry id="146b-2f63-829c-162a" name="Kalliope Mortar" publicationId="48c2-d023-0069-001a" hidden="false" collective="true" import="true" type="upgrade">
+                <selectionEntry id="146b-2f63-829c-162a" name="Kalliope Mortar" publicationId="9fab-fea7-a93c-2074" hidden="false" collective="true" import="true" type="upgrade" page="153">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4501-77a0-8aa0-2087" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02c4-756b-65ee-a445" type="min"/>
@@ -6163,7 +6212,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     <infoLink id="8336-4fd9-3a75-764f" name="Kalliope Mortar" hidden="false" targetId="9b5b-0a4d-9551-9741" type="profile"/>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -6174,6 +6223,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="61d5-868d-4e3a-90ab" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="38f4-3543-4be4-940a" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="3fba-9099-4a95-a1c1" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="19af-d74f-ccd3-9a25" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="1568-3730-cce3-342a" name="Militia Field Gun w/ Thunderblast Cannon" hidden="false" collective="false" import="true" type="model">
@@ -6213,9 +6263,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="602d-2f20-45bb-9d9e" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="9231-183c-b97b-63f9" id="9c68-3362-410d-98df" name="Heavy Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="25f2-a1be-476a-b49e" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="394-8e5c-36b8-fc84" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
+          <categoryLinks>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="2df9-e427-9348-f1b9" primary="false" name="Skirmish Sub-type:"/>
+          </categoryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -6266,6 +6320,21 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c7a-3931-5426-4a8c" type="max"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c16-a692-1008-296b" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Heavy Stubber" hidden="false" id="fa2e-99a0-99be-d41" type="selectionEntry" targetId="f227-a61a-3215-932b">
+          <modifiers>
+            <modifier type="set" value="Hull (Front) Mounted Heavy Stubber" field="name"/>
+          </modifiers>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5e51-bbf4-4e3e-9cb8"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3427-a97b-ede-1d5d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </entryLink>
+        <entryLink import="true" name="Searchlights" hidden="false" id="b942-504b-ff9-c03e" type="selectionEntry" targetId="4ae3-79b4-6051-505e">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6b43-c84e-832f-e644"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8219-2b5a-c3-af3e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -6525,6 +6594,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="7893-6300-4c6a-c56d" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="82a5-2fe3-a1b8-fda6" name="Militia Unit Sub-type" hidden="false" targetId="66b2-c457-4d5e-8041" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="1792-f720-e57-a0d" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="59a4-7b61-600a-c457" id="a8d1-fd7c-ffe0-b89d" primary="false" name="Skirmish Sub-type:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="95e0-6a85-8f47-912e" name="Outrider Sergeant" hidden="false" collective="false" import="true" type="model">
@@ -6533,7 +6603,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5fe-d644-1f50-2660" type="max"/>
           </constraints>
           <profiles>
-            <profile id="3ae7-decd-5fc2-89b2" name="Outrider Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="3ae7-decd-5fc2-89b2" name="Outrider Sergeant" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="153">
               <modifiers>
                 <modifier type="set" field="e593-6b3c-f169-04f0" value="4+">
                   <conditions>
@@ -6578,13 +6648,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </modifierGroup>
               </modifierGroups>
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Light, Militia, Character)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Light, Militia, Skirmish, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
                 <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
@@ -6620,6 +6690,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <categoryLink targetId="6d79-a3e4-381f-7b0f" id="81f9-8d40-48cb-aaae" name="Cavalry Unit Type" primary="false"/>
             <categoryLink targetId="bff2-ae16-74a8-8712" id="f59e-7339-45d1-b8ce" name="Light Sub-type" primary="false"/>
             <categoryLink targetId="66b2-c457-4d5e-8041" id="e8f5-365b-4a5c-8438" name="Militia Unit Sub-type" primary="false"/>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="ff45-bd56-2c4e-e52e" primary="false" name="Skirmish Sub-type:"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="adaf-346a-a591-f44c" name="1.1) Weapon (Exchange Laspistol/Autopistol)" hidden="false" collective="false" import="true" defaultSelectionEntryId="f52f-9556-369c-6cb5">
@@ -6801,10 +6872,10 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="1d96-081c-a63d-229b" name="2) One Militia Outrider in the unit may take one of the following:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="1d96-081c-a63d-229b" name="2) For every five, one Militia Outrider in the unit may take one of the following:" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9479-cc12-2df3-8251" type="max"/>
-            <constraint field="selections" scope="ffb1-4b4b-b88c-832c" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7333-6de7-5cb5-9399" type="max"/>
+            <constraint field="selections" scope="ffb1-4b4b-b88c-832c" value="21" percentValue="true" shared="true" includeChildSelections="true" includeChildForces="false" id="7333-6de7-5cb5-9399" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="bae9-887f-1478-9194" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e0f3-3743-a9d0-f5f1" type="selectionEntry">
@@ -6875,6 +6946,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6edc-06e4-4c7d-8124" name="Cavalry Unit Type" primary="false"/>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="130b-2e5b-4ce1-8e76" name="Light Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="46d2-b475-463f-9ecb" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="e659-8c6e-e593-f2f3" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="688b-7dee-f649-d1ec" name="Outrider w/ Autopistol" hidden="false" collective="false" import="true" type="model">
@@ -6882,7 +6954,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="14" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="87da-7eb7-7ac9-91b7" type="max"/>
               </constraints>
               <profiles>
-                <profile id="78e1-37b3-e7bf-5f86" name="Outrider" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                <profile id="78e1-37b3-e7bf-5f86" name="Outrider" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="153">
                   <modifiers>
                     <modifier type="set" field="e593-6b3c-f169-04f0" value="4+">
                       <conditions>
@@ -6927,13 +6999,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     </modifierGroup>
                   </modifierGroups>
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Light, Militia)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Light, Skirmish, Militia)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">14</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
-                    <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
+                    <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
@@ -6965,6 +7037,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="6d79-a3e4-381f-7b0f" id="735c-1356-4d20-b71c" name="Cavalry Unit Type" primary="false"/>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="3cab-f9fd-4fdd-afd1" name="Light Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="f91e-8dd5-45a4-9546" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="682e-79d3-c2f1-eed9" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="a956-492e-0dcd-0191" name="Outrider w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7012,6 +7085,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="6d79-a3e4-381f-7b0f" id="e4ad-0d11-4df1-a453" name="Cavalry Unit Type" primary="false"/>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="7b3b-7c7e-4405-af14" name="Light Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="cb16-531d-4113-a127" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="4c40-1403-bf92-9bb5" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="2c47-a35f-14c2-c8c9" name="Outrider w/ Autopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7059,9 +7133,13 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="6d79-a3e4-381f-7b0f" id="6889-bdbc-45d4-9d8f" name="Cavalry Unit Type" primary="false"/>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="1c97-5658-4310-8eda" name="Light Sub-type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="12d7-b3f2-44c9-9d80" name="Militia Unit Sub-type" primary="false"/>
+                <categoryLink targetId="59a4-7b61-600a-c457" id="37cd-7a19-61b8-ad8" primary="false" name="Skirmish Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
+          <categoryLinks>
+            <categoryLink targetId="59a4-7b61-600a-c457" id="65af-8fa9-d5c1-761a" primary="false" name="Skirmish Sub-type:"/>
+          </categoryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -7151,7 +7229,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 </infoLink>
                 <infoLink id="58ad-8531-9c7a-069b" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rage (1)"/>
+                    <modifier type="set" field="name" value="Rage (2)">
+                      <comment>Panoptica 153</comment>
+                    </modifier>
                   </modifiers>
                 </infoLink>
               </infoLinks>
@@ -7355,7 +7435,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf16-6ef1-3368-888b" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e2d2-7e4b-3098-6344" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile"/>
+                <infoLink id="e2d2-7e4b-3098-6344" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile" publicationId="9fab-fea7-a93c-2074" page="153"/>
+                <infoLink name="Fleet (X)" hidden="false" id="ccbd-1740-55de-28d8" type="rule" targetId="ddc9-0b4b-78da-bbd2">
+                  <modifiers>
+                    <modifier type="set" value="Fleet (1)" field="name"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <entryLinks>
                 <entryLink id="7d0b-c992-17b5-bdd3" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -7384,6 +7469,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b4fc-b544-4e3c-b7a6" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="bf00-1592-48f8-b030" name="Militia Unit Sub-type" primary="false"/>
                 <categoryLink targetId="59a4-7b61-600a-c457" id="75db-0f24-431a-9a5f" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="f88-c8e5-718b-e6a5" primary="false" name="Light Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="fcc4-81ff-34ab-4fda" name="Handler w/ Autopistol" hidden="false" collective="false" import="true" type="model">
@@ -7391,7 +7477,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c09-9301-debb-dead" type="max"/>
               </constraints>
               <profiles>
-                <profile id="cdf4-cc09-70bf-647d" name="Militia Handler" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                <profile id="cdf4-cc09-70bf-647d" name="Militia Handler" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="153">
                   <modifiers>
                     <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
                       <conditions>
@@ -7426,7 +7512,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                     </modifierGroup>
                   </modifierGroups>
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Skirmish)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Militia, Light, Skirmish)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
@@ -7473,7 +7559,15 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="f838-57ef-4763-bbff" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="0082-f9cb-4705-9748" name="Militia Unit Sub-type" primary="false"/>
                 <categoryLink targetId="59a4-7b61-600a-c457" id="b5cc-4d26-4231-b12b" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="a58-f2fb-2b1e-64b4" primary="false" name="Light Sub-type:"/>
               </categoryLinks>
+              <infoLinks>
+                <infoLink name="Fleet (X)" hidden="false" id="c904-c6fc-9c2e-8397" type="rule" targetId="ddc9-0b4b-78da-bbd2">
+                  <modifiers>
+                    <modifier type="set" value="Fleet (1)" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
             </selectionEntry>
             <selectionEntry id="0aad-ede5-6b66-7ee4" name="Handler w/ Auitopistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
               <modifiers>
@@ -7487,7 +7581,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8fe5-6a25-28f4-ffcd" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="4d73-db28-5a6d-a83a" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile"/>
+                <infoLink id="4d73-db28-5a6d-a83a" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile" publicationId="9fab-fea7-a93c-2074" page="153"/>
+                <infoLink name="Fleet (X)" hidden="false" id="3488-8394-c437-4dee" type="rule" targetId="ddc9-0b4b-78da-bbd2">
+                  <modifiers>
+                    <modifier type="set" value="Fleet (1)" field="name"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <entryLinks>
                 <entryLink id="5b91-99ea-ecb9-fd94" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -7519,6 +7618,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="d8d3-a1e0-425d-aeac" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="ceb7-95da-4ab3-bfc8" name="Militia Unit Sub-type" primary="false"/>
                 <categoryLink targetId="59a4-7b61-600a-c457" id="152c-c64b-4fd5-a945" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="eb7-94ba-23e9-765d" primary="false" name="Light Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
             <selectionEntry id="7c34-c649-ca22-2b7f" name="Handler w/ Laspistol &amp; Chainaxe" hidden="false" collective="false" import="true" type="model">
@@ -7533,7 +7633,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0c8d-5ee3-1dc0-f013" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="e75a-332a-68b8-9a2f" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile"/>
+                <infoLink id="e75a-332a-68b8-9a2f" name="Militia Handler" hidden="false" targetId="cdf4-cc09-70bf-647d" type="profile" publicationId="9fab-fea7-a93c-2074" page="153"/>
+                <infoLink name="Fleet (X)" hidden="false" id="751b-a98-a08a-325" type="rule" targetId="ddc9-0b4b-78da-bbd2">
+                  <modifiers>
+                    <modifier type="set" value="Fleet (1)" field="name"/>
+                  </modifiers>
+                </infoLink>
               </infoLinks>
               <entryLinks>
                 <entryLink id="42e3-6418-0fa4-049a" name="Flak Armour" hidden="false" collective="false" import="true" targetId="0251-8365-9efb-61a7" type="selectionEntry">
@@ -7565,6 +7670,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c9d8-1024-4e55-a722" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="66b2-c457-4d5e-8041" id="c85e-7a30-43a0-816a" name="Militia Unit Sub-type" primary="false"/>
                 <categoryLink targetId="59a4-7b61-600a-c457" id="216f-20a7-4f71-bae5" name="Skirmish Sub-type" primary="false"/>
+                <categoryLink targetId="bff2-ae16-74a8-8712" id="d4f0-2256-f898-1701" primary="false" name="Light Sub-type:"/>
               </categoryLinks>
             </selectionEntry>
           </selectionEntries>
@@ -7574,7 +7680,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="26"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
       </costs>
       <categoryLinks>
         <categoryLink name="SA or IM Unit" hidden="false" id="82a2-cd04-8cb1-47a6" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -7589,7 +7695,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink name="SA or IM Unit" hidden="false" id="b992-e902-7e12-3a5b" targetId="4aca-2849-7f41-0200" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="153a-959d-1e6d-e612" name="Sentinel" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="153a-959d-1e6d-e612" name="Sentinel" hidden="false" collective="false" import="true" type="model" publicationId="9fab-fea7-a93c-2074" page="153">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="25ff-1ac4-46cc-01fc" type="min"/>
             <constraint field="selections" scope="parent" value="5" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b74-6893-5a9c-8358" type="max"/>
@@ -7620,7 +7726,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <infoLink id="d440-93c9-a2fa-1d83" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
           </infoLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
           </costs>
           <categoryLinks>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="b86e-0b1e-454a-88c8" name="Infantry Unit Type" primary="false"/>
@@ -7682,7 +7788,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
             </entryLink>
-            <entryLink id="9ce5-6753-bb82-eb20" name="Missile Launcher w/Frag &amp; Krak Missiles" hidden="false" collective="false" import="true" targetId="536a-06f1-e49b-8c6b" type="selectionEntry">
+            <entryLink id="9ce5-6753-bb82-eb20" name="Missile Launcher w/ Frag/Krak/Flak Missiles" hidden="false" collective="false" import="true" targetId="9426-c270-d276-0d3b" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="5" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="163d-2080-a8db-12f1" type="max"/>
               </constraints>
@@ -7779,6 +7885,11 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="120"/>
       </costs>
+      <rules>
+        <rule name="Divisio Aeronautica Air Superiority" hidden="false" id="85b0-b34a-80bf-641b" publicationId="9fab-fea7-a93c-2074" page="153">
+          <description>A unit or model with this special rule may be placed into Combat Air Patrol at the beginning of the battle, before any models are deployed onto the table. Models assigned to Combat Air Patrol are not deployed onto the battlefield and remain in Reserves – however, no Reserves rolls are made for these models. Instead, the controlling player gains access to the Combat Air Patrol Advanced Reaction.</description>
+        </rule>
+      </rules>
     </selectionEntry>
     <selectionEntry id="fbb6-c597-3edb-1506" name="IM - Rapier Battery" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
       <selectionEntries>
@@ -8059,7 +8170,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
       <profiles>
         <profile id="eeda-ee0e-9834-1f99" name="Malcador Heavy Tank" publicationId="48c2-d023-0069-001a" page="32" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
-            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Third-line, Reinforced)</characteristic>
+            <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Third-line, Fast, Reinforced)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
@@ -8080,6 +8191,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
         <categoryLink id="c98c-1e49-f597-b96b" name="Third-line Unit Sub-type" hidden="false" targetId="cdaa-645b-fda7-8556" primary="false"/>
         <categoryLink id="1dd4-afa1-484c-6dc2" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="6fd7-ced4-3f66-597b" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="0ea2-efb5-b7af-226e" id="f1ad-6221-eddc-5565" primary="false" name="Fast Sub-type:"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="1acb-b4b5-6e27-78fd" name="1) May exchange its Hull (Front) Mounted battlecannon for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="abdb-32fb-e348-8145">
@@ -8089,9 +8201,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
           </constraints>
           <entryLinks>
             <entryLink id="abdb-32fb-e348-8145" name="Battle Cannon" hidden="false" collective="false" import="true" targetId="7638-4f76-51f0-b0fa" type="selectionEntry"/>
-            <entryLink id="88de-8066-537c-a1a0" name="Vanquisher Battle Cannon" hidden="false" collective="false" import="true" targetId="196c-cb26-f3e0-e0db" type="selectionEntry">
+            <entryLink id="88de-8066-537c-a1a0" name="Vanquisher Battle Cannon w/ Co-Axial Autocannon" hidden="false" collective="false" import="true" targetId="ea4a-7e8d-4ea3-a24c" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
             </entryLink>
             <entryLink id="2e66-ab8b-9d9a-4c8e" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
@@ -8116,9 +8228,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
             </entryLink>
-            <entryLink id="4341-916e-2971-4715" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry">
+            <entryLink id="4341-916e-2971-4715" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="154">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -8149,12 +8261,12 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <modifier type="set" field="name" value="Hull (Left) &amp; Hull (Right) Mounted Heavy Flamer"/>
               </modifiers>
             </entryLink>
-            <entryLink id="c533-875f-79f8-9270" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
+            <entryLink id="c533-875f-79f8-9270" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="154">
               <modifiers>
                 <modifier type="set" field="name" value="Hull (Left) &amp; Hull (Right) Mounted Lascannon"/>
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -8247,7 +8359,7 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
             <entryLink id="de9d-b6b4-e0c4-dd51" name="Heavy Flamer" hidden="false" collective="false" import="true" targetId="5507-b432-3b4c-df12" type="selectionEntry"/>
             <entryLink id="a640-b637-4baf-009a" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
             </entryLink>
             <entryLink id="c6a6-13c7-3267-7c49" name="Heavy Bolter" hidden="false" collective="false" import="true" targetId="07fd-c24a-9235-4206" type="selectionEntry"/>
@@ -8339,9 +8451,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="e3b5-d8ed-5651-5a34" name="Turret Mounted Gravis Autocannons" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="e3b5-d8ed-5651-5a34" name="Turret Mounted Exterminator Autocannons" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="154">
               <entryLinks>
-                <entryLink id="708d-23d9-2423-6b39" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry">
+                <entryLink id="708d-23d9-2423-6b39" name="Exterminator Autocannon" hidden="false" collective="false" import="true" targetId="682a-c2bd-16c-db51" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75c9-1817-3cfb-581a" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2717-fa93-bbc2-eae9" type="max"/>
@@ -8352,9 +8464,9 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="43ef-8220-97f6-530e" name="Turret Mounted Gravis Lascannons" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="43ef-8220-97f6-530e" name="Turret Mounted Gravis Heavy Lascannons" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="154">
               <entryLinks>
-                <entryLink id="637d-6160-842a-f400" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
+                <entryLink id="637d-6160-842a-f400" name="Gravis Heavy Lascannon" hidden="false" collective="false" import="true" targetId="2013-7e81-b563-e7ac" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f52a-34fb-9b25-4e21" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f17-f646-62e6-5d54" type="max"/>
@@ -8426,55 +8538,39 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <profiles>
                 <profile id="5f6a-4688-67cf-c9ee" name="Earthshaker Gun Carriage" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Artillery, Heavy)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Static Artillery, Heavy)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">-</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">-</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">-</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">-</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
-                <categoryLink id="b1dd-86aa-1c7a-ec38" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
                 <categoryLink id="144f-3d8d-5a77-0ef0" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="8d85-3a58-4ba7-66fa" primary="false" name="Infantry Unit Type"/>
+                <categoryLink targetId="8664-76f2-fe15-751a" id="b262-d127-a0aa-2018" primary="false" name="Static Artillery"/>
               </categoryLinks>
-              <selectionEntries>
-                <selectionEntry id="d168-dd0e-70a6-9d34" name="Earthshaker cannon" publicationId="d0df-7166-5cd3-89fd" page="25" hidden="false" collective="true" import="true" type="upgrade">
-                  <profiles>
-                    <profile id="90f1-a1ab-4577-abbc" name="Earthshaker cannon" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                      <characteristics>
-                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">240&quot;</characteristic>
-                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
-                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Barrage, Large Blast (5&quot;), Shred, Pinning</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink id="593f-f3c2-2c84-01f2" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
-                    <infoLink id="d55b-182b-d9ca-ec4a" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="name" value="Large Blast (5&quot;)"/>
-                      </modifiers>
-                    </infoLink>
-                    <infoLink id="9b6c-55a3-bc76-e076" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-                    <infoLink id="b70c-47fe-ac15-4e47" name="Shred" hidden="false" targetId="5e7e-1628-8174-6f2c" type="rule"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
+              <infoLinks>
+                <infoLink name="Immobile" hidden="false" id="363-d38b-af5-f841" type="rule" targetId="a676-e911-8581-8a72"/>
+                <infoLink name="Bulky (X)" hidden="false" id="7d4e-e584-4185-1a5c" type="rule" targetId="676c-7b75-4b6f-9405">
+                  <modifiers>
+                    <modifier type="set" value="Bulky (5)" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <entryLinks>
+                <entryLink import="true" name="Earthshaker Cannon" hidden="false" id="1f4-e2f8-5b0-b3df" type="selectionEntry" targetId="cc2e-df5f-1778-29d8"/>
+              </entryLinks>
             </selectionEntry>
             <selectionEntry id="0b06-8fcf-968f-9ca3" name="Medusa Gun Carriage" hidden="false" collective="true" import="true" type="model">
               <constraints>
@@ -8483,59 +8579,39 @@ Note that only Militia Medicae selected as part of a Detachment with the Ogryn C
               <profiles>
                 <profile id="a57a-049b-e64e-6da7" name="Medusa Gun Carriage" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
                   <characteristics>
-                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Artillery, Heavy)</characteristic>
+                    <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Static Artillery, Heavy)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">3</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">-</characteristic>
                     <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">-</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">-</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">-</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <categoryLinks>
                 <categoryLink id="fc24-4a7a-d3d4-d5ee" name="Heavy Sub-type" hidden="false" targetId="9231-183c-b97b-63f9" primary="false"/>
-                <categoryLink id="b8f5-f67b-e34f-462b" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="56c3-c63f-7684-21ef" primary="false" name="Infantry Unit Type"/>
+                <categoryLink targetId="8664-76f2-fe15-751a" id="99b9-27b8-9133-a05b" primary="false" name="Static Artillery"/>
               </categoryLinks>
-              <selectionEntries>
-                <selectionEntry id="cd2d-75a6-629e-8433" name="Medusa Mortar" publicationId="d0df-7166-5cd3-89fd" page="26" hidden="false" collective="true" import="true" type="upgrade">
-                  <profiles>
-                    <profile id="b07d-0b5b-c25f-f214" name="Medusa Mortar" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-                      <characteristics>
-                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
-                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
-                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Barrage, Large Blast (5&quot;), Pinning, Rending (6+)</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink id="f577-364f-72b2-b4db" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
-                    <infoLink id="87c4-f4a1-5d61-8a79" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="name" value="Large Blast (5&quot;)"/>
-                      </modifiers>
-                    </infoLink>
-                    <infoLink id="8b46-e709-1ff1-1022" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-                    <infoLink id="923a-6fa0-d14b-cb17" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="name" value="Rending (6+)"/>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="90"/>
               </costs>
+              <infoLinks>
+                <infoLink name="Immobile" hidden="false" id="9ce6-e2b1-420a-ecd5" type="rule" targetId="a676-e911-8581-8a72"/>
+                <infoLink name="Bulky (X)" hidden="false" id="4a29-8861-ce6b-830a" type="rule" targetId="676c-7b75-4b6f-9405">
+                  <modifiers>
+                    <modifier type="set" value="Bulky (5)" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+              <entryLinks>
+                <entryLink import="true" name="Medusa Mortar" hidden="false" id="2113-d05d-f34-cb12" type="selectionEntry" targetId="aafc-7435-8805-0e0f"/>
+              </entryLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -8857,10 +8933,13 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="250"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Assault Vehicle" hidden="false" id="d15a-c523-5735-4eea" type="rule" targetId="aa61-11f6-2bb5-7c0e"/>
+      </infoLinks>
     </selectionEntry>
-    <selectionEntry id="ecd4-2b5f-a98a-5093" name="IM - Baneblade Super-heavy Battle Tank" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="ecd4-2b5f-a98a-5093" name="IM - Baneblade Super-heavy Battle Tank" publicationId="9fab-fea7-a93c-2074" hidden="false" collective="false" import="true" type="unit" page="154">
       <profiles>
-        <profile id="47a8-d183-2e1b-52d6" name="Militia Baneblade" publicationId="48c2-d023-0069-001a" page="36" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="47a8-d183-2e1b-52d6" name="Militia Baneblade" publicationId="9fab-fea7-a93c-2074" page="154" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Third-line, Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
@@ -8868,7 +8947,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
-            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">9</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
             <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">-</characteristic>
           </characteristics>
@@ -9092,7 +9171,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="400"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e6d5-9f6a-b62b-c477" name="IM - Ogryn Brute Squad" publicationId="48c2-d023-0069-001a" hidden="false" collective="false" import="true" type="unit">
@@ -9100,6 +9179,11 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <modifier type="add" field="category" value="8f42-a824-fb5f-8fea">
           <conditions>
             <condition field="selections" scope="e6d5-9f6a-b62b-c477" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-47b8-3add-1d38" type="equalTo"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" field="category" value="9231-183c-b97b-63f9">
+          <conditions>
+            <condition field="selections" scope="e6d5-9f6a-b62b-c477" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0c0f-f751-cc4e-4951" type="atLeast"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -9208,6 +9292,11 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                 <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
                   <conditions>
                     <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b192-2b6f-ad8c-959f" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="Infantry (Militia, Heavy, Monstrous, Character)" field="ddd7-6f5c-a939-b69e">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="de21-368a-567e-3280" childId="0c0f-f751-cc4e-4951" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -9528,14 +9617,6 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
               </costs>
             </entryLink>
-            <entryLink id="f673-e9b0-d924-8fe8" name="Boarding Shield" hidden="false" collective="false" import="true" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="10" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8b04-73a5-1fc7-17a7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-              </costs>
-            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="2130-1a97-ee67-879d" name="1) Ogryn Brutes" hidden="false" collective="false" import="true" defaultSelectionEntryId="28ff-6c27-f4aa-c26c">
@@ -9573,6 +9654,11 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                     <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
                       <conditions>
                         <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b192-2b6f-ad8c-959f" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="Infantry (Militia, Heavy, Monstrous, Character)" field="ddd7-6f5c-a939-b69e">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="0c0f-f751-cc4e-4951" shared="true" includeChildSelections="true"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -9637,6 +9723,14 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="09c5-94c0-68b1-4feb" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink import="true" name="Boarding Shield" hidden="false" id="34d3-8301-bd1-4b9f" collective="false" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="a497-35e7-ffe8-adb2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="edc-1508-841f-727d" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
@@ -9685,6 +9779,14 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
                   </constraints>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Boarding Shield" hidden="false" id="f673-e9b0-d924-8fe8" collective="false" targetId="0c0f-f751-cc4e-4951" type="selectionEntry">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="8b04-73a5-1fc7-17a7" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="4b7f-1042-b30a-3fe" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -10141,9 +10243,9 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c968-7a28-02aa-5ade" type="max"/>
       </constraints>
       <profiles>
-        <profile id="bf68-2f8c-e803-967b" name="Militia Standard" publicationId="48c2-d023-0069-001a" page="37" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+        <profile id="bf68-2f8c-e803-967b" name="Militia Standard" publicationId="9fab-fea7-a93c-2074" page="154" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with a Militia standard adds +1 to the Wounds score used to decide if they win a Combat in the Assault phase and gains the Stubborn special rule.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit that includes at least one model with a Militia standard adds +1 to the Wounds score used to decide if they win a Combat in the Assault phase and gains the Stubborn special rule. A unit that includes at least one model with a Militia Standard gains the Line Sub-type for as long as that model is part of the unit.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -11092,7 +11194,7 @@ equal to the number of Militia Gunners in the unit when making a Shooting Attack
               <profiles>
                 <profile id="bccd-681c-4acc-d9dd" name="Merchant Princeling" publicationId="48c2-d023-0069-001a" page="6" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
                   <characteristics>
-                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All of the weapons possessed by a Warlord with this Trait gain the Master-crafted special rule. Before any models are placed onto the battlefield as part of deployment, the controlling player of this Warlord may select a single unit under their control – designated as the ‘Lifeguard’ unit. The Lifeguard unit must be composed entirely of models with the Militia Unit Sub-type, and all models in the Lifeguard unit gain the Heavy Unit Sub-type, if they did not already have it, and may re-roll all failed To Hit rolls of ‘1’ made in any phase or as part of a Reaction. The Warlord with this Trait must be deployed as part of the Lifeguard unit and may not voluntarily leave that unit during play. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty.</characteristic>
+                    <characteristic name="Text" typeId="c68e-2cda-b67b-baca">All of the weapons possessed by a Warlord with this Trait gain the Master-crafted special rule. Before any models are placed onto the battlefield as part of deployment, the controlling player of this Warlord may select a single unit under their control – designated as the ‘Lifeguard’ unit. The Lifeguard unit must be composed entirely of models with the Militia Unit Sub-type, and all models in the Lifeguard unit gain the Heavy Unit Sub-type, if they did not already have it, and may re-roll all failed To Hit rolls of ‘1’ made in any phase or as part of a Reaction. The Warlord with this Trait must be deployed as part of the Lifeguard unit and may not voluntarily leave that unit during play. In addition, an army whose Warlord has this Trait may make an additional Reaction during their opponent’s Assault phase as long as the Warlord has not been removed as a casualty. If the Warlord has a Retinue unit of any kind, this unit is instead automatically designated as the Warlord’s Lifeguard unit.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -11358,8 +11460,8 @@ Once deployed onto the battlefield, all units selected in this manner are treate
 
 When assigning additional models to units using the Among the Ranks and Militia Medicae Support special rules, each unit selected using the Strength in Numbers special rule is considered separate and may have models assigned to it as per the normal rules as the controlling player chooses.</description>
     </rule>
-    <rule id="976f-9e14-413c-5bea" name="Emplaced" publicationId="48c2-d023-0069-001a" page="24" hidden="false">
-      <description>A unit that includes any models with this special rule may only make the Return Fire or Overwatch Core Reactions or the Interceptor Advanced Reaction – no other Reaction of any kind may be made. Additionally, if forced to Fall Back for any reason, all models in the unit are immediately removed as casualties.</description>
+    <rule id="976f-9e14-413c-5bea" name="Emplaced" publicationId="9fab-fea7-a93c-2074" page="153" hidden="false">
+      <description>A unit that includes any models with this special rule may only make the Return Fire or Overwatch Core Reactions or the Interceptor Advanced Reaction – no other Reaction of any kind may be made. Additionally, if forced to Fall Back for any reason, all models in the unit are immediately removed as casualties. If taken as part of a Mortalis Assault Force Organisation Chart, a unit that includes any models with this Special Rule may only make the Suppress Reaction.</description>
     </rule>
   </sharedRules>
   <catalogueLinks>

--- a/2022 - LA - Alpha Legion.cat
+++ b/2022 - LA - Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1967-627b-83d8-12ce" name="LA - XX: Alpha Legion" revision="2050" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1967-627b-83d8-12ce" name="LA - XX: Alpha Legion" revision="2051" battleScribeVersion="2.03" authorName="Alphalas" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="2275-5253-2421-7383" name="Rewards of Trechery" hidden="false">
       <modifiers>

--- a/2022 - LA - Blood Angels.cat
+++ b/2022 - LA - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="38ec-5d74-5a4a-da90" name="LA -  IX: Blood Angels" revision="2041" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="38ec-5d74-5a4a-da90" name="LA -  IX: Blood Angels" revision="2042" battleScribeVersion="2.03" authorName="Jon K &quot;Alphalas&quot;" authorContact="Twitter: Alphalas_ Discord: Alphalas#8789" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="1900-3f09-f47b-bed2" name="Praetor" hidden="false" collective="false" import="false" targetId="03be-5d55-d05a-771d" type="selectionEntry">
       <comment>template_id_5798-3fc7-4d4c-ad41</comment>

--- a/2022 - LA - Dark Angels.cat
+++ b/2022 - LA - Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="497d-19e0-6dbd-f87e" name="LA -   I: Dark Angels" revision="2032" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="497d-19e0-6dbd-f87e" name="LA -   I: Dark Angels" revision="2033" battleScribeVersion="2.03" authorName="revivedtitan" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="7653-8041-8d1c-c872" name="Dreadwing Interemptor Squad" hidden="false" collective="false" import="false" targetId="3008-e8ed-9e97-71c9" type="selectionEntry">
       <categoryLinks>

--- a/2022 - LA - Death Guard.cat
+++ b/2022 - LA - Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="19ea-eb9d-4ccb-e3c0" name="LA -  XIV: Death Guard" revision="2031" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="19ea-eb9d-4ccb-e3c0" name="LA -  XIV: Death Guard" revision="2032" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="fb89-32c1-bdc5-2e3d" name="Mortarion" hidden="false" collective="false" import="false" targetId="7427-bdfa-c359-ebb8" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Emperor's Children.cat
+++ b/2022 - LA - Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9025-fdec-da16-541a" name="LA -   III: Emperor&apos;s Children" revision="2037" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9025-fdec-da16-541a" name="LA -   III: Emperor&apos;s Children" revision="2038" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="a119-3943-4b8b-b651" name="Captain Lucius" hidden="true" collective="false" import="false" targetId="0707-1e4b-27da-9cd4" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Imperial Fists.cat
+++ b/2022 - LA - Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="d371-14a7-bf2b-1f20" name="LA -   VII: Imperial Fists" revision="2032" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="d371-14a7-bf2b-1f20" name="LA -   VII: Imperial Fists" revision="2033" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="b3e4-1487-4ab7-7515" name="Alexis Polux" hidden="false" collective="false" import="false" targetId="9229-b4f9-2213-9672" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Iron Hands.cat
+++ b/2022 - LA - Iron Hands.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d6af-8c96-7a52-cbfa" name="LA -  X: Iron Hands" revision="2038" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="d6af-8c96-7a52-cbfa" name="LA -  X: Iron Hands" revision="2039" battleScribeVersion="2.03" authorName="Figjam Bohica" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="6107-168e-198e-2e94" name="X: Iron Hands" hidden="false" collective="false" import="false" targetId="bfc9-c99c-bf8a-3917" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Iron Warriors.cat
+++ b/2022 - LA - Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3ecd-fb2c-3822-1e2a" name="LA -   IV: Iron Warriors" revision="2037" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="3ecd-fb2c-3822-1e2a" name="LA -   IV: Iron Warriors" revision="2038" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="fe10-3104-0252-96de" name="Nârik Dreygur" hidden="true" collective="false" import="false" targetId="ac97-c8ce-16ba-9c49" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Night Lords.cat
+++ b/2022 - LA - Night Lords.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="78a6-f5a2-5a5c-ef0d" name="LA -   VIII: Night Lords" revision="2038" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="78a6-f5a2-5a5c-ef0d" name="LA -   VIII: Night Lords" revision="2039" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="f491-c7fa-f6d3-917d" name="Contekar Terminator Squad" hidden="false" collective="false" import="false" targetId="837e-c3ca-437e-dfbf" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Raven Guard.cat
+++ b/2022 - LA - Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="64c8-badb-7d2a-890a" name="LA - XIX: Raven Guard" revision="2028" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="64c8-badb-7d2a-890a" name="LA - XIX: Raven Guard" revision="2029" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="84cc-e59c-174e-fb25" name="Mor Deythan Squad" hidden="false" collective="false" import="false" targetId="c268-08ac-5b90-d034" type="selectionEntry">
       <categoryLinks>

--- a/2022 - LA - Salamanders.cat
+++ b/2022 - LA - Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="765e-788c-dde3-4683" name="LA -  XVIII: Salamanders" revision="2036" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="765e-788c-dde3-4683" name="LA -  XVIII: Salamanders" revision="2037" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="93d2-b1cb-b684-a9b3" name="XVIII: Salamanders" hidden="false" collective="false" import="false" targetId="c805-ca3a-ff93-5e2f" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Sons of Horus.cat
+++ b/2022 - LA - Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="db61-af86-a1bc-6c06" name="LA -  XVI: Sons of Horus" revision="2035" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="db61-af86-a1bc-6c06" name="LA -  XVI: Sons of Horus" revision="2036" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <entryLinks>
     <entryLink id="c2a2-9b6d-b384-3f43" name="XVI: Sons of Horus" hidden="false" collective="false" import="false" targetId="01b4-57c7-bf61-2abf" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Space Wolves.cat
+++ b/2022 - LA - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6454-e18-28f-fbfb" name="LA -   VI: Space Wolves" revision="2032" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="6454-e18-28f-fbfb" name="LA -   VI: Space Wolves" revision="2033" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="ff53-69d9-ec0b-9caa" name="VI: Space Wolves" hidden="false" collective="false" import="false" targetId="4916-965e-8339-44f6" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Thousand Sons.cat
+++ b/2022 - LA - Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="4e6e-662e-84a8-fb62" name="LA -  XV: Thousand Sons" revision="2033" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="4e6e-662e-84a8-fb62" name="LA -  XV: Thousand Sons" revision="2034" battleScribeVersion="2.03" authorName="Arkangelmark5" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <publications>
     <publication id="f743-7ff9-a2f3-01c7" name="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" shortName="Axandria IV" publisher="Exemplary Battles of the Age of Darkness: The Axandria IV Incident" publicationDate="9/16/2022" publisherUrl="https://www.warhammer-community.com/wp-content/uploads/2022/09/3mVvZrTG9XOWeVxv.pdf"/>
   </publications>

--- a/2022 - LA - Ultramarines.cat
+++ b/2022 - LA - Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="88c9-63e-51f3-80f1" name="LA -  XIII: Ultramarines" revision="2038" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="88c9-63e-51f3-80f1" name="LA -  XIII: Ultramarines" revision="2039" battleScribeVersion="2.03" authorName="Mr_Dark, Alphalas, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="76b3-52d9-a195-2b31" name="XIII: Ultramarines" hidden="false" collective="false" import="false" targetId="8e0f-3552-8842-f281" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - White Scars.cat
+++ b/2022 - LA - White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8b8a-6a95-2974-215a" name="LA -   V: White Scars" revision="2036" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="8b8a-6a95-2974-215a" name="LA -   V: White Scars" revision="2037" battleScribeVersion="2.03" authorName="Mr_Dark, UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="a738-6a11-dfe7-286c" name="V: White Scars" hidden="false" collective="false" import="false" targetId="e01e-5cdd-e512-8353" type="selectionEntry">
       <modifiers>

--- a/2022 - LA - Word Bearers.cat
+++ b/2022 - LA - Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9edf-435d-b09a-9dd3" name="LA -  XVII: Word Bearers" revision="2033" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="9edf-435d-b09a-9dd3" name="LA -  XVII: Word Bearers" revision="2034" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="821c-0c83-5ed0-ff6b" name="Harbinger of Chaos Restriction" hidden="false">
       <modifiers>

--- a/2022 - LA - World Eaters.cat
+++ b/2022 - LA - World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1344-db36-36c1-e861" name="LA -  XII: World Eaters" revision="2037" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1344-db36-36c1-e861" name="LA -  XII: World Eaters" revision="2038" battleScribeVersion="2.03" authorName="UrsinePatriarch" authorContact="BSData Developers Discord" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <entryLinks>
     <entryLink id="d647-fd99-73e0-bd57" name="Angron" hidden="false" collective="false" import="false" targetId="6352-8efa-0cc4-cfa7" type="selectionEntry">
       <modifiers>

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2dde-e269-90db-8d33" name="LI - Assassins and Agents" revision="2010" battleScribeVersion="2.03" authorName="Maye Gelt" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="2dde-e269-90db-8d33" name="LI - Assassins and Agents" revision="2011" battleScribeVersion="2.03" authorName="Maye Gelt" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry id="c1fd-3919-f4bf-a990" name="Clade Adamus Assassin" publicationId="15a4-fc68-502d-48a9" page="120" hidden="false" collective="false" import="true" type="unit">
       <profiles>

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -30,6 +30,11 @@
         <infoLink id="2226-c89c-e5fc-3d45" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
         <infoLink id="e9b1-bf56-095d-f9ff" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
         <infoLink id="84e7-571f-66d3-0eee" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink name="Preferred Enemy (X)" hidden="false" id="acaa-9381-ae43-788" type="rule" targetId="37ab-d4db-891a-de8c">
+          <modifiers>
+            <modifier type="set" value="Preferred Enemy (Characters)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0023-51b9-50b3-c66b" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
@@ -166,10 +171,13 @@
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="ca4f-321c-519e-b34b" name="Clade Callidus Assassin" publicationId="15a4-fc68-502d-48a9" page="116" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="75fb-99a0-9ecb-7166" name="Clade Callidus Assassin" publicationId="15a4-fc68-502d-48a9" page="116" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+        <profile id="75fb-99a0-9ecb-7166" name="Clade Callidus Assassin" publicationId="9fab-fea7-a93c-2074" page="147" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Assassin, Light)</characteristic>
             <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
@@ -177,7 +185,7 @@
             <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
             <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-            <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
             <characteristic name="I" typeId="62d3-22d7-2d49-52dc">6</characteristic>
             <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
             <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
@@ -215,7 +223,10 @@
 may not be targeted for a Shooting Attack, Charge or
 Reaction of any kind by an enemy unit as long as the unit
 with polymorphine has not made an attack of any kind
-during the battle. Once a unit or model with polymorphine has made a Shootin gAttack (including during a Reaction) then polymorphine has no futher effect.</characteristic>
+during the battle. Once a unit or model with polymorphine has made a Shootin gAttack (including during a Reaction) then polymorphine has no futher effect. 
+
+
+In addition, Polymorphine’s effects immediately end if an enemy unit ends its Movement in the Controlling Player’s Movement Phase within 6” of the model equipped with Polymorphine</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -293,22 +304,25 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="7c0a-f6df-88f7-e29a" name="Clade Culexus Assassin" publicationId="15a4-fc68-502d-48a9" page="115" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="4564-a7a7-fad5-89fb" name="Clade Culexus Assassin" publicationId="15a4-fc68-502d-48a9" page="115" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+        <profile id="4564-a7a7-fad5-89fb" name="Clade Culexus Assassin" publicationId="9fab-fea7-a93c-2074" page="147" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Assassin, Light, Anathema)</characteristic>
-            <characteristic name="Move" typeId="893e-2d76-8f04-44e5"/>
-            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84"/>
-            <characteristic name="BS" typeId="74ae-c840-0036-d244"/>
-            <characteristic name="S" typeId="e478-41d4-a092-48a8"/>
-            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f"/>
-            <characteristic name="W" typeId="57ee-1126-32a9-5672"/>
-            <characteristic name="I" typeId="62d3-22d7-2d49-52dc"/>
-            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0"/>
-            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727"/>
-            <characteristic name="Save" typeId="e593-6b3c-f169-04f0"/>
+            <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
+            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+            <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+            <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
+            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
+            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
+            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
+            <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
+            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -368,12 +382,12 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3751-a32f-b1ae-218b" type="max"/>
           </constraints>
           <profiles>
-            <profile id="b94f-7e4b-0c02-57c1" name="Animus Speculum" publicationId="15a4-fc68-502d-48a9" page="115" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="b94f-7e4b-0c02-57c1" name="Animus Speculum" publicationId="9fab-fea7-a93c-2074" page="147" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">4</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Rending (6+), Psy-shock</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1, Rending (6+), Psy-shock, Soul-Death</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -385,6 +399,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             </infoLink>
             <infoLink id="6f37-90be-2c76-8d80" name="Template Weapons" hidden="false" targetId="5e0e-88e6-db81-5a70" type="rule"/>
             <infoLink id="7224-8b40-2056-cd8c" name="Psy-shock" hidden="false" targetId="f372-a365-a036-cbc4" type="rule"/>
+            <infoLink name="Soul-Death" hidden="false" id="36a7-b143-b58b-fc15" type="rule" targetId="ced3-6b8d-80a2-a6fd"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -419,6 +434,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="a3c0-cb13-aef7-8838" name="Clade Eversor Assassin" publicationId="15a4-fc68-502d-48a9" page="118" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -454,6 +472,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <modifier type="set" field="name" value="Counter-Attack (1)"/>
           </modifiers>
         </infoLink>
+        <infoLink name="No Witness" hidden="false" id="69f0-1fb1-a1bc-f4fa" type="rule" targetId="e053-84f7-23bf-75ef"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3e59-53b2-2e89-e5c7" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
@@ -543,6 +562,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="c109-bb90-d38f-ce07" name="Clade Vanus Infocyte Assassin" publicationId="15a4-fc68-502d-48a9" page="124" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -586,9 +608,12 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79fd-e7c2-2ddb-d8de" type="max"/>
           </constraints>
           <profiles>
-            <profile id="9320-3e0b-895d-a211" name="Auspectre" publicationId="15a4-fc68-502d-48a9" page="125" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+            <profile id="9320-3e0b-895d-a211" name="Auspectre" publicationId="9fab-fea7-a93c-2074" page="148" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Enemy models cannot be deployed using the Infiltrate special rule within 18&quot; of a model with an auspectre. In addition, when any enemy unit is deployed to the battlefield from Reserves, a model with an auspectre may make the Interceptor Advanced Reaction (see page 309 of the Horus Heresy: Age of Darkness rulebook) without expending a point of the Reactive player&apos;s Reaction Allotment. This does not allow the unit to make more than one Reaction per Phase, but does allow the controlling player to exceed the normal threee Reaction limit in a given Phase. Instead of usin gthe profile of a weapon the model has, a model with the auspectre may instead make a Leadership test. If the Leadership test is passed, the controlling player may instead make a Shooting Attack with any Defensive weapon available to any model with the Vehicle Unit Type (both friendly or enemy within 12&quot;, that is in range and line of sight of the targeted model. If the Leadership test is failed, the model may not make an Interceptor Advanced Reaction.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Enemy models cannot be deployed using the Infiltrate special rule within 18&quot; of a model with an auspectre. In addition, when any enemy unit is deployed to the battlefield from Reserves, a model with an auspectre may make the Interceptor Advanced Reaction (see page 309 of the Horus Heresy: Age of Darkness rulebook) without expending a point of the Reactive player&apos;s Reaction Allotment. This does not allow the unit to make more than one Reaction per Phase, but does allow the controlling player to exceed the normal threee Reaction limit in a given Phase. Instead of usin gthe profile of a weapon the model has, a model with the auspectre may instead make a Leadership test. If the Leadership test is passed, the controlling player may instead make a Shooting Attack with any Defensive weapon available to any model with the Vehicle Unit Type (both friendly or enemy within 12&quot;, that is in range and line of sight of the targeted model. If the Leadership test is failed, the model may not make an Interceptor Advanced Reaction.
+
+
+Note that weapons selected to fire in this manner must still follow the rules and restrictions placed upon them by their mountings, Unit Types, or Unit Sub-types, such as allowed targets for reactions in the case of Knights and Titans only being allowed to react to other Knights and Titans, Super-heavy Vehicles, Lumbering Flyers or any model with 8 or more Wounds.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -632,7 +657,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
           <profiles>
             <profile id="ee8b-8261-7110-fede" name="Autotomic Servo-limbs" publicationId="15a4-fc68-502d-48a9" page="125" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Once per battle, at the start of any turn, the controlling player of the model with the autotomagic servo-limbs may choose to grant the model the Hit &amp; Run special rule unitil the start of their next turn.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Once per battle, at the start of any turn, the Controlling Player of a model with Autotomic Servo-Limbs may choose to grant that model the Counter-Attack (2) Special Rule until the start of their next turn.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -659,6 +684,9 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="b1b9-e6d8-a7c2-f252" name="Clade Venenum Assassin" publicationId="15a4-fc68-502d-48a9" page="122" hidden="false" collective="false" import="true" type="unit">
       <profiles>
@@ -689,6 +717,11 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
         <infoLink id="a53d-cd94-834c-1e22" name="Scout" hidden="false" targetId="aacf-9a7e-982d-b793" type="rule"/>
         <infoLink id="be2a-a441-9b99-7967" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
         <infoLink id="7283-74ac-17f6-31af" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
+        <infoLink name="Fleet (X)" hidden="false" id="3d07-6d12-55b1-d8b8" type="rule" targetId="ddc9-0b4b-78da-bbd2">
+          <modifiers>
+            <modifier type="set" value="Fleet (2)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f41a-599a-1e9e-1289" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
@@ -702,12 +735,12 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bca-0088-cd73-686f" type="max"/>
           </constraints>
           <profiles>
-            <profile id="023d-47fb-270f-5970" name="Hookfang" publicationId="15a4-fc68-502d-48a9" page="123" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="023d-47fb-270f-5970" name="Hookfang" publicationId="9fab-fea7-a93c-2074" page="175" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Poisoned (3+), The Venem</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Poisoned (3+), The Venem, Breaching (5+)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -720,6 +753,11 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <infoLink id="ff6b-6778-161d-803b" name="Poisoned (X)" hidden="false" targetId="e70e-23ea-3251-0edb" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Poisoned (3+)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Breaching (X)" hidden="false" id="a6bf-b290-1928-e1ae" type="rule" targetId="a760-f736-1bf3-fa3c">
+              <modifiers>
+                <modifier type="set" value="Breaching (5+)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -782,10 +820,13 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
       </costs>
+      <modifiers>
+        <modifier type="add" value="d615-c0e4-6d17-107e" field="category"/>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="0b9a-903b-c3de-5075" name="Clade Vindicare Assassin" publicationId="15a4-fc68-502d-48a9" page="114" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="faee-8596-e437-1e0e" name="Clade Vindicare Assassin" publicationId="15a4-fc68-502d-48a9" page="114" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+        <profile id="faee-8596-e437-1e0e" name="Clade Vindicare Assassin" publicationId="9fab-fea7-a93c-2074" page="147" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
           <characteristics>
             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Character, Assassin, Light)</characteristic>
             <characteristic name="Move" typeId="893e-2d76-8f04-44e5">7</characteristic>
@@ -793,7 +834,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
             <characteristic name="BS" typeId="74ae-c840-0036-d244">8</characteristic>
             <characteristic name="S" typeId="e478-41d4-a092-48a8">4</characteristic>
             <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
-            <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
+            <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
             <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
             <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
             <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">10</characteristic>
@@ -825,7 +866,7 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">100&quot;</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Murderous Strike (5+), Rending (6+), Sniper</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Murderous Strike (5+), Rending (6+), Sniper, Brutal (2)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -841,6 +882,11 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
               </modifiers>
             </infoLink>
             <infoLink id="71d6-43fd-0ac5-3f88" name="Sniper" hidden="false" targetId="9cd8-e726-5dbe-b106" type="rule"/>
+            <infoLink name="Brutal (X)" hidden="false" id="d5b0-1635-bcb1-66ca" type="rule" targetId="5079-1fec-d32b-8b84">
+              <modifiers>
+                <modifier type="set" value="Brutal (2)" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -905,13 +951,23 @@ during the battle. Once a unit or model with polymorphine has made a Shootin gAt
       <profiles>
         <profile id="c516-0961-ebaf-22c5" name="Panoply Of The Assassin" publicationId="15a4-fc68-502d-48a9" page="156" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Models with the Panoply of the Assassin have a 4+ Armour Save and a 4+ Invulnerable Save.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Models with the Panoply of the Assassin have a 4+ Armour Save and a 4+ Invulnerable Save. A model equipped with the Panoply of the Assassin also gains Frag Grenades, and the Hit &amp; Run and Shrouded (5+) Special Rules.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Shrouded (X)" hidden="false" id="8be5-fd46-67b1-463a" type="rule" targetId="10c3-fdb0-089f-ca65">
+          <modifiers>
+            <modifier type="set" value="Shrouded (5+)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Hit &amp; Run" hidden="false" id="177-1073-a70c-a58b" type="rule" targetId="5986-e960-d432-affd"/>
+        <infoLink name="Frag Grenades" hidden="false" id="af80-babf-aaae-a26b" type="profile" targetId="ccc0-4896-212b-4d53"/>
+        <infoLink name="Grenades" hidden="false" id="7ee7-d82f-f993-1c46" type="rule" targetId="6f5f-8f7c-d18b-cd42"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="7363-5a05-4102-24fa" name="Clade Assassins (Loyalist)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>

--- a/2022 - LI - Assassins.cat
+++ b/2022 - LI - Assassins.cat
@@ -1259,6 +1259,7 @@ Note that weapons selected to fire in this manner must still follow the rules a
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e250-c088-29d2-b595" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink import="true" name="Psychic Discipline: Anathemata" hidden="false" id="5bd7-5384-ad6b-f68" type="selectionEntry" targetId="c6ec-edc0-034e-ed45" publicationId="9fab-fea7-a93c-2074" page="150"/>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
@@ -1327,12 +1328,12 @@ Note that weapons selected to fire in this manner must still follow the rules a
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="88c8-dd2a-1298-c9b4" type="max"/>
               </constraints>
               <profiles>
-                <profile id="5476-f035-bffd-0917" name="Lidless Stare (Psychic Weapon)" hidden="false" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon">
+                <profile id="5476-f035-bffd-0917" name="Lidless Stare (Psychic Weapon)" hidden="false" typeId="cede-0217-1b10-2a34" typeName="Psychic Weapon" publicationId="9fab-fea7-a93c-2074" page="173">
                   <characteristics>
                     <characteristic name="Range" typeId="62ec-fbf5-5252-0d17">Template</characteristic>
                     <characteristic name="Strength" typeId="17ff-12e7-77d3-2fbe">2</characteristic>
                     <characteristic name="AP" typeId="f431-a7b9-d9d0-36c9">-</characteristic>
-                    <characteristic name="Type" typeId="2159-62b6-4337-d516">Pinning, Force</characteristic>
+                    <characteristic name="Type" typeId="2159-62b6-4337-d516">Assault 1, Pinning, Force, Instant Death</characteristic>
                   </characteristics>
                 </profile>
               </profiles>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2f2b-1f31-c455-1776" name="LI - Custodes" revision="2020" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="2f2b-1f31-c455-1776" name="LI - Custodes" revision="2021" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="ccca-a9de-0cd9-f8be" name="Legio Custodes" hidden="false">
       <infoLinks>
@@ -2085,7 +2085,7 @@
                         <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Reduce the Strength characteristic of Shooting Attacks made against a unit in which the majority of models have a Tarsus Buckler by -2 (to a minimum of 1).</characteristic>
                       </characteristics>
                     </profile>
-                    <profile name="Tarsus Buckler (Weapon)" hidden="false" id="4f79-af8a-8232-f9e" page="" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                    <profile name="Tarsus Buckler (Weapon)" hidden="false" id="4f79-af8a-8232-f9e" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                       <characteristics>
                         <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                         <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -2303,7 +2303,7 @@
       <profiles>
         <profile id="09e1-791e-2a1c-d2c8" name="Praesidium Shield" publicationId="15a4-fc68-502d-48a9" page="156" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A Praesidium shield confers a 5+ Invulnerable Save – this does not stack with existing Invulnerable Saves and if a model has more than one such save, the controlling player must select one to use against any Wounds inflicted on that model. In addition, a model with a Praesidium shield cannot claim bonus attacks for having more than one melee weapon, or make attacks during the Assault phase using a weapon with the Two-handed special rule.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with a Praesidium Shield adds +1 to its Invulnerable Save (to a maximum of 3+) or an Invulnerable Save of 6+ if they do not already possess one. In addition, a model with a Praesidium Shield cannot claim bonus attacks for having more than one melee weapon, or make attacks during the Assault phase using a weapon with the Two-Handed Special Rule.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -3215,6 +3215,7 @@ A model with the Infantry Unit Type that selects a Custodes Gyrfalcon jetbike as
             <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
           </modifiers>
         </infoLink>
+        <infoLink name="Skilled Rider" hidden="false" id="63f0-fd9c-15cc-3dce" type="rule" targetId="89cc-21e0-bee2-6a89"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -417,7 +417,7 @@
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="d2ee-04cb-5f8a-2642" scope="roster" value="3000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
+                <condition field="d2ee-04cb-5f8a-2642" scope="roster" value="2000" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="any" type="lessThan"/>
                 <condition field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d926-652f-8436-30ce" type="instanceOf"/>
               </conditions>
             </conditionGroup>
@@ -456,7 +456,7 @@
           </profiles>
           <rules>
             <rule id="e88c-465d-fc13-d71d" name="Tribune of the Golden Legion" hidden="false">
-              <description>A model with this specialrule may only be included in the Primary Detachment of an army with a total value of at least 3,000 points. Furthermore, unless Constantin Valdor is also part of the same army, a model with this specialrule must be chosen as the army’s Warlor</description>
+              <description>A model with this Special Rule may only be included in the Primary Detachment of an army with a total value of at least 2,000 points. Furthermore, unless Constantin Valdor is also part of the same army, a model with this Special Rule must be chosen as the army’s Warlord.</description>
             </rule>
           </rules>
           <infoLinks>
@@ -490,12 +490,12 @@
                   </costs>
                 </entryLink>
                 <entryLink id="80d7-e8ea-f760-7c32" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="6909-d6c6-8d05-0e57" type="selectionEntry"/>
-                <entryLink id="9464-6576-ae15-0d36" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+                <entryLink id="9464-6576-ae15-0d36" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry"/>
+                <entryLink id="0281-832b-19e6-50c1" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
                   </costs>
                 </entryLink>
-                <entryLink id="0281-832b-19e6-50c1" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry"/>
                 <entryLink id="d420-be7e-17f3-efcc" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
@@ -513,7 +513,7 @@
                 </entryLink>
                 <entryLink id="9146-b43c-8dc9-b221" name="Paragon Glaive" hidden="false" collective="false" import="true" targetId="a9fc-4298-7b35-8ef4" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
                 <entryLink id="9f52-9a89-827f-3e02" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="1334-e423-944e-9499" type="selectionEntry"/>
@@ -782,13 +782,16 @@
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31a2-da16-84b9-22a8" type="max"/>
                   </constraints>
+                  <costs>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+                  </costs>
                 </entryLink>
                 <entryLink id="04f1-3907-5bb5-d06e" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d50a-ec64-213f-e67b" type="max"/>
                   </constraints>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                   </costs>
                 </entryLink>
                 <entryLink id="f114-1264-5f4d-862c" name="Pyrithite Spear" hidden="false" collective="false" import="true" targetId="4620-e360-7dd2-f908" type="selectionEntry">
@@ -854,7 +857,7 @@
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="60"/>
           </costs>
           <categoryLinks>
             <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="ab03-271b-4a46-8fbe" name="Infantry Unit Type" primary="false"/>
@@ -1281,7 +1284,7 @@
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                   </characteristics>
@@ -1533,7 +1536,7 @@
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">4</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                   </characteristics>
@@ -1815,7 +1818,7 @@
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">3</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">5</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
@@ -2089,7 +2092,7 @@
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="70"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="55"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="2b53-452a-435d-f29d" name="Venatari w/ Venatari Lance" hidden="false" collective="false" import="true" type="upgrade">
@@ -2134,7 +2137,7 @@
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="80"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="65"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2173,7 +2176,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8a39-6452-e075-c8d6" name="Sagittarum Guard Squad" publicationId="15a4-fc68-502d-48a9" page="31" hidden="false" collective="false" import="true" type="unit">
@@ -3430,12 +3433,12 @@ the Front Armour during the same Phase.�</characteristic>
               </costs>
             </entryLink>
             <entryLink id="affd-2143-1c9e-17f6" name="Sentinel Warblade" hidden="false" collective="false" import="true" targetId="6909-d6c6-8d05-0e57" type="selectionEntry"/>
-            <entryLink id="1be3-d3ac-4975-5411" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry">
+            <entryLink id="1be3-d3ac-4975-5411" name="Paragon Blade" hidden="false" collective="false" import="true" targetId="2ab9-0e45-405e-056b" type="selectionEntry"/>
+            <entryLink id="2fbc-0de5-8b8f-ca1d" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
               </costs>
             </entryLink>
-            <entryLink id="2fbc-0de5-8b8f-ca1d" name="Meridian Swords" hidden="false" collective="false" import="true" targetId="9664-33bc-927e-5ba3" type="selectionEntry"/>
             <entryLink id="35b7-60c7-d938-44f7" name="Solarite Power Gauntlet" hidden="false" collective="false" import="true" targetId="9786-98f2-bdab-5103" type="selectionEntry">
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
@@ -3453,7 +3456,7 @@ the Front Armour during the same Phase.�</characteristic>
             </entryLink>
             <entryLink id="4b62-44bd-1fe7-2c96" name="Paragon Glaive" hidden="false" collective="false" import="true" targetId="a9fc-4298-7b35-8ef4" type="selectionEntry">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
             </entryLink>
             <entryLink id="dc58-66af-84f4-984f" name="Guardian Axe" hidden="false" collective="false" import="true" targetId="1334-e423-944e-9499" type="selectionEntry"/>
@@ -3903,7 +3906,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
     </selectionEntry>
     <selectionEntry id="6526-bdfb-4ebe-6e0a" name="Orion Assault Dropship" hidden="false" collective="false" import="true" type="model">
       <profiles>
-        <profile id="9365-981d-d422-7c4a" name="Orion Assault Dropship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="9365-981d-d422-7c4a" name="Orion Assault Dropship" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="144">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Flyer, Hover, Lumbering, Transport</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">19</characteristic>
@@ -3912,7 +3915,7 @@ During a Reaction made in any Phase, a player may not choose to activate a model
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">11</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">7</characteristic>
-            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">24</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">36</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">Rear</characteristic>
           </characteristics>
         </profile>
@@ -4292,7 +4295,12 @@ Lightning Blows (X) special rule, but do benefit from any other special rules po
   <sharedProfiles>
     <profile id="3ddf-fb5c-220a-9581" name="Golden Exemplar (Warlord Trait)" publicationId="15a4-fc68-502d-48a9" page="17" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
       <characteristics>
-        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any combat with at least one friendly model within 12&quot; of a Warlord with this Trait, or a combat which includes a Warlord with this Trait, gains a bonus of +1 to the number of Wounds caused for the purposes of deciding which side has won a combat during the Assault phase. In addition, while Engaged in a Challenge a Warlord with this Trait adds a bonus of +1 to their Attacks and Initiative Characteristics.</characteristic>
+        <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any combat with at least one friendly model within 12&quot; of a Warlord with this Trait, or a combat which includes a Warlord with this Trait, gains a bonus of +1 to the number of Wounds caused for the purposes of deciding which side has won a combat during the Assault phase. In addition, while Engaged in a Challenge a Warlord with this Trait adds a bonus of +1 to their Attacks and Initiative Characteristics.
+
+
+Furthermore, the first Reaction made in each Game Turn by this
+Warlord and any unit he has joined does not use up a point of the
+Controlling Player’s Reaction Allotment.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/2022 - LI - Custodes.cat
+++ b/2022 - LI - Custodes.cat
@@ -2080,9 +2080,17 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b14-abce-9f97-9fe0" type="max"/>
                   </constraints>
                   <profiles>
-                    <profile id="ba8a-0da7-2ccc-c438" name="Tarsus Buckler" publicationId="15a4-fc68-502d-48a9" page="158" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                    <profile id="ba8a-0da7-2ccc-c438" name="Tarsus Buckler (Wargear)" publicationId="15a4-fc68-502d-48a9" page="158" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                       <characteristics>
                         <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Reduce the Strength characteristic of Shooting Attacks made against a unit in which the majority of models have a Tarsus Buckler by -2 (to a minimum of 1).</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile name="Tarsus Buckler (Weapon)" hidden="false" id="4f79-af8a-8232-f9e" page="" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
+                        <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+1</characteristic>
+                        <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
+                        <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -2748,7 +2756,7 @@
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">Template</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
-            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">6</characteristic>
+            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
             <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 1, Torrent (9&quot;)</characteristic>
           </characteristics>
         </profile>
@@ -2767,7 +2775,7 @@
     </selectionEntry>
     <selectionEntry id="2b1d-a84d-9b3f-8ad6" name="Infernus Firepike" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="17b5-35b3-97b8-7b9f" name="Infernus Firepike" hidden="false" targetId="8ee5-48ce-ca14-40e4" type="profile"/>
+        <infoLink id="17b5-35b3-97b8-7b9f" name="Infernus Firepike" hidden="false" targetId="8ee5-48ce-ca14-40e4" type="profile" publicationId="9fab-fea7-a93c-2074" page="171"/>
         <infoLink id="ef92-d64b-522a-5966" name="Torrent (X)" hidden="false" targetId="5cfb-fc94-e6db-43b8" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Torrent (9&quot;)"/>
@@ -3004,18 +3012,23 @@
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d6f-2162-5a4f-d8b0" type="max"/>
           </constraints>
           <profiles>
-            <profile id="377d-10d8-9548-a5ac" name="Telemon Cestus" publicationId="15a4-fc68-502d-48a9" page="150" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="377d-10d8-9548-a5ac" name="Telemon Cestus" publicationId="9fab-fea7-a93c-2074" page="175" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Sunder</characteristic>
+                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Specialist Weapon, Sunder, Brutal (3)</characteristic>
               </characteristics>
             </profile>
           </profiles>
           <infoLinks>
             <infoLink id="5af8-74d5-7765-899d" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule"/>
             <infoLink id="d9cc-aa8c-ffda-00ee" name="Specialist Weapon" hidden="false" targetId="1a1f-3c9b-b097-5886" type="rule"/>
+            <infoLink name="Brutal (X)" hidden="false" id="5299-e42-9dd-63cd" type="rule" targetId="5079-1fec-d32b-8b84">
+              <modifiers>
+                <modifier type="set" value="Brutal (3)" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -4043,12 +4056,12 @@ During a Reaction made in any Phase, a player may not choose to activate a model
     </selectionEntry>
     <selectionEntry id="2357-23af-0317-1a79" name="Adrastus Bolt Caliver" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="1658-9859-8604-bf91" name="Adrastus Bolt Caliver - (Bolt Volley)" publicationId="15a4-fc68-502d-48a9" page="145" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+        <profile id="1658-9859-8604-bf91" name="Adrastus Bolt Caliver - (Bolt Volley)" publicationId="9fab-fea7-a93c-2074" page="171" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 4</characteristic>
+            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 4, Shred Pinning</characteristic>
           </characteristics>
         </profile>
         <profile id="c953-8e34-9c71-92e2" name="Adrastus Bolt Caliver - (Disintegrator)" publicationId="15a4-fc68-502d-48a9" page="146" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
@@ -4064,6 +4077,8 @@ During a Reaction made in any Phase, a player may not choose to activate a model
         <infoLink id="aba3-d0ba-2ccf-89bc" name="Gets Hot" hidden="false" targetId="679f-9d97-5ace-a652" type="rule"/>
         <infoLink id="0efd-9220-7866-2b14" name="Instant Death" hidden="false" targetId="9e96-fff1-b916-d9a3" type="rule"/>
         <infoLink id="3e1e-bd96-b92e-c3b6" name="One Use/One Shot" hidden="false" targetId="df0c-5423-b892-491e" type="rule"/>
+        <infoLink name="Shred" hidden="false" id="fc5-7c64-d2ae-6916" type="rule" targetId="5e7e-1628-8174-6f2c"/>
+        <infoLink name="Pinning" hidden="false" id="6889-97af-de6-c5c2" type="rule" targetId="1c96-205c-59a0-3cf2"/>
       </infoLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -6645,10 +6645,10 @@ No more than one Knight Vestal may be assigned to any given unit. Once assigned
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d956-d8c6-9427-4faa" type="max"/>
           </constraints>
           <profiles>
-            <profile id="2167-88b0-0dcd-76b6" name="Vratine Grenade Launcher - Krak" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="2167-88b0-0dcd-76b6" name="Vratine Grenade Launcher - Krak" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" publicationId="9fab-fea7-a93c-2074" page="171">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">5</characteristic>
+                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">6</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                 <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Assault 1</characteristic>
               </characteristics>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -48,7 +48,7 @@
       <rules>
         <rule id="e2d9-fe0d-1717-3a37" name="Anathema Sub-type" publicationId="15a4-fc68-502d-48a9" page="129" hidden="false">
           <description>• A unit that includes at least one model with the Anathema Sub-type may not be directly targeted by any Psychic Power or use any Psychic power or make attacks with a Psychic Weapon, Psychic Powers whose effects would otherwise be applied to a unit that includes at least one model with the Anathema Sub-type (due to area of effect, scattering or other rules) have no effect, but are not cancelled and may continue to affect other units.
-• A model with the Anathema Sub-type that is allocated Wounds caused by a Psychic Weapon (which is any weapon granted to a unit or model by a Psychic Discipline) will always fail to Wound without any dice being rolled and any special rules attached to that Psychic Weapon will not trigger. Any Wounds allocated to a model with the Anathema Unit Sub-type caused by a Force Weapon gain no benefit from the Force special rules, but are otherwise resolved as normal. These effects do not apply to a model with the Transport Sub-type that has models with the Anathema Sub-type Embarked within, unless the model with the Transport Sub-type also has the Anathema Sub-type.
+• A model with the Anathema Sub-type that is allocated Wounds caused by a Psychic Weapon (which is any weapon granted to a unit or model by a Psychic Discipline) will always fail to Wound without any dice being rolled and any special rules attached to that Psychic Weapon will not trigger. Any Wounds allocated to a model with the Anathema Unit Sub-type caused by a Force Weapon gain no benefit from the Force, Achean Force, or Soul Tear Special Rules, but are otherwise resolved as normal.
 • All models that no not have the Anathema Sub-type but are part of a unit that includes one of more models with the Anathema Sub-type, suffer a penalty of -2 to their Leadership Characteristic. Any unit with at least one model within 6&quot; of a model with th eAnathema Sub-type suffers a penalty of -1 to the Leadership of all models in the unit that do not also have the Anathema Sub-type, or -2 if that unit includes one of more models with the Corrupted Unit Sub-type. Note that these two penalties are not cumulative; they apply only the more severe penalty. However, they do stack with other special that modify Leadership (such as Fear (X)).
 • A unit that is Embarked on a Vehicle, Fortification or Building suffers no penalties to its Leadership Characteristic due to the Anathema Sub-type, However, units with the Stubborn special rule do suffer penalties to their Leadership from the effects of this Sub-type (note that this only applies to the Stubborn special rule, and other special rules that ignore panalties to Leadership ignore the effects of the Anathema Sub-type).
 
@@ -564,7 +564,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <infoLink id="b8b4-eca3-ad62-92ed" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="3b0d-35f3-aae3-11f4" name="3) May upgrade any one weapon to have the Master-crafted" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="3b0d-35f3-aae3-11f4" name="2) May upgrade any one weapon to have the Master-crafted" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca9-b397-e0a5-6dc0" type="max"/>
               </constraints>
@@ -587,10 +587,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup id="38f4-d578-753e-0f66" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="836d-c1f4-167c-8b3b">
+            <selectionEntryGroup id="38f4-d578-753e-0f66" name="1) Select any Two Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="836d-c1f4-167c-8b3b">
               <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ce2-1709-cefb-45b8" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfa4-4935-9781-6f26" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ce2-1709-cefb-45b8" type="min"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfa4-4935-9781-6f26" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="836d-c1f4-167c-8b3b" name="Execution Blade" hidden="false" collective="false" import="true" targetId="adc6-3519-204d-2921" type="selectionEntry">
@@ -850,136 +850,128 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="e4ea-0dcf-667c-14a9" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e26f-47fb-d98a-7b69">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7fb-9884-dd57-71f7" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f012-b2fb-d6c1-675f" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="e26f-47fb-d98a-7b69" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
+                <entryLink import="true" name="Archaeotech Pistol" hidden="false" id="8129-b104-c3dd-4864" collective="false" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Bolt Pistol">
+                    <modifier type="set" value="Master-crafted Archaeotech Pistol" field="name">
                       <conditions>
-                        <condition field="selections" scope="6be2-d4b9-2a64-f164" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                        <condition type="equalTo" value="1" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e7c-bc91-2e20-30db" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a5d6-7cab-cdf8-d9d2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="f824-1ed8-cf48-3ebb" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                    <infoLink name="Master-crafted" hidden="false" id="2716-8188-f325-c4d" targetId="6de0-55b0-bf21-48b9" type="rule">
                       <modifiers>
-                        <modifier type="set" field="hidden" value="true">
+                        <modifier type="set" value="true" field="hidden">
                           <conditions>
-                            <condition field="selections" scope="6be2-d4b9-2a64-f164" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                </entryLink>
-                <entryLink id="0fc0-9e0c-d12d-d0fa" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Hand Flamer">
-                      <conditions>
-                        <condition field="selections" scope="6be2-d4b9-2a64-f164" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="286a-e455-5e38-4a09" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="8050-bc67-0471-fda2" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="6be2-d4b9-2a64-f164" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                </entryLink>
-                <entryLink id="e0d5-8c67-d7b3-5c30" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Needle Pistol">
-                      <conditions>
-                        <condition field="selections" scope="6be2-d4b9-2a64-f164" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461b-9f7a-b9d3-5ad5" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="5ca3-e3af-5f2d-686f" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="6be2-d4b9-2a64-f164" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                            <condition type="equalTo" value="0" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                    <cost name="Pts" hidden="false" id="7209-9588-76b6-7ac1" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
-                <entryLink id="af10-93fe-af53-02dd" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                <entryLink import="true" name="Bolt Pistol" hidden="false" id="aa85-5d0-acf7-808a" collective="false" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Plasma Pistol">
+                    <modifier type="set" value="Master-crafted Bolt Pistol" field="name">
                       <conditions>
-                        <condition field="selections" scope="6be2-d4b9-2a64-f164" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                        <condition type="equalTo" value="1" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6944-af71-138d-5c7d" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3368-1d9e-877e-743e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="681f-761e-58c2-597f" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                    <infoLink name="Master-crafted" hidden="false" id="41d5-cc9d-827-3bb0" targetId="6de0-55b0-bf21-48b9" type="rule">
                       <modifiers>
-                        <modifier type="set" field="hidden" value="true">
+                        <modifier type="set" value="true" field="hidden">
                           <conditions>
-                            <condition field="selections" scope="6be2-d4b9-2a64-f164" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                            <condition type="equalTo" value="0" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink import="true" name="Hand Flamer" hidden="false" id="ed69-ca20-2696-e4a7" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-crafted Hand Flamer" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3e12-e694-3f3c-c5b2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink name="Master-crafted" hidden="false" id="7b50-88d-a73c-8bca" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink import="true" name="Needle Pistol" hidden="false" id="9da0-73b5-8123-9b7c" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-crafted Needle Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ad23-a5a6-1119-7640" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink name="Master-crafted" hidden="false" id="507a-8da3-1103-aee6" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" hidden="false" id="4012-4238-a136-56ca" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
-                <entryLink id="e179-e3ee-8df0-22b6" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                <entryLink import="true" name="Plasma Pistol" hidden="false" id="1715-7ced-6324-7a58" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Archaeotech Pistol">
+                    <modifier type="set" value="Master-crafted Plasma Pistol" field="name">
                       <conditions>
-                        <condition field="selections" scope="6be2-d4b9-2a64-f164" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                        <condition type="equalTo" value="1" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5b5-2756-dc23-48d8" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b353-8590-affb-4b50" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="96a5-e085-aea6-e39e" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                    <infoLink name="Master-crafted" hidden="false" id="ff5d-e341-cecb-16ba" targetId="6de0-55b0-bf21-48b9" type="rule">
                       <modifiers>
-                        <modifier type="set" field="hidden" value="true">
+                        <modifier type="set" value="true" field="hidden">
                           <conditions>
-                            <condition field="selections" scope="6be2-d4b9-2a64-f164" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="242a-f8b0-21dc-b14a" type="equalTo"/>
+                            <condition type="equalTo" value="0" field="selections" scope="6be2-d4b9-2a64-f164" childId="242a-f8b0-21dc-b14a" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" hidden="false" id="3eeb-57b7-dbc8-f0a2" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1764,7 +1756,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
           <profiles>
             <profile id="715c-8943-4b28-4923" name="Silent Fury" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
-                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character, Light, Skirmish, Anathema)</characteristic>
+                <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Cavalry (Character, Light, Antigrav, Skirmish, Anathema)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">18</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
                 <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
@@ -1802,6 +1794,11 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <infoLink id="a0a5-78ee-d2a8-f6fd" name="Hatred (X)" hidden="false" targetId="dc0b-fe69-6b71-e0a4" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Hatred (Psyker, Daemon, Corrupted)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Firing Protocols (X)" hidden="false" id="ce4e-8e21-f7ef-f8c8" type="rule" targetId="32a3-f599-5c92-2945">
+              <modifiers>
+                <modifier type="set" value="Firing Protocols (2)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>
@@ -2337,6 +2334,9 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <categoryLink targetId="59a4-7b61-600a-c457" id="2e60-51f0-4ba3-b06f" name="Skirmish Sub-type" primary="false"/>
             <categoryLink targetId="7e5d-d73e-8ff4-7345" id="a3fe-a911-4218-b75d" name="Anathema Sub-type" primary="false"/>
           </categoryLinks>
+          <modifiers>
+            <modifier type="add" value="4303-1348-cce4-9501" field="category"/>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -2535,15 +2535,15 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Light, Line, Anathema)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">5</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -2594,10 +2594,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f98c-acc3-52c0-e438" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="4392-b160-a459-ffa3" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="e483-2f6c-c2ba-3f8e" type="selectionEntry" targetId="9196-3af7-9545-e62b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a2b7-7a5c-a930-f133" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0dae-83a0-d0f6-fdf2" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2446-c313-2576-883f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c04a-57a3-d10a-87f1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -2730,10 +2730,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8791-dbb3-014e-be55" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="b53b-ab7a-7273-3ad4" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="3fb4-da57-2cb5-ed30" type="selectionEntry" targetId="9196-3af7-9545-e62b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ac6-8b0e-547e-cd1d" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4073-ad39-c541-78c4" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7bfb-58e9-e49a-d382" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f3a-3933-2648-a0a4" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -2887,10 +2887,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="f2cf-2e79-dc8c-6235" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="68c0-0595-dd4a-e40c" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="4e76-6753-e15a-3765" type="selectionEntry" targetId="9196-3af7-9545-e62b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bbb2-9355-d197-73c9" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="659c-988c-6c2c-bb25" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3c20-ca7-6ea1-88b2" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="19ea-62a5-6d54-b53" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -2933,7 +2933,6 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       <categoryLinks>
         <categoryLink id="2dbd-dcff-f67e-57d4" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
         <categoryLink id="bee8-f85e-9c9f-71cc" name="Character" hidden="false" targetId="f75a-d5c1-59ba-5c5a" primary="false"/>
-        <categoryLink id="9647-5e27-4d48-5fca" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
         <categoryLink id="e35f-892f-5cf1-8766" name="Light Sub-type" hidden="false" targetId="bff2-ae16-74a8-8712" primary="false"/>
         <categoryLink id="9141-5125-97c3-d1cb" name="Anathema Sub-type" hidden="false" targetId="7e5d-d73e-8ff4-7345" primary="false"/>
         <categoryLink id="55eb-6a52-6728-5484" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" targetId="b6d7-6924-37fb-dd32" primary="false"/>
@@ -2962,8 +2961,14 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             </profile>
           </profiles>
           <rules>
-            <rule id="e181-6e76-57bc-4118" name="Vigilant Covenant" publicationId="15a4-fc68-502d-48a9" page="51" hidden="false">
-              <description>A Knight Vestal Covenant is selected as any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins and any models are deployed to the battlefield, each model in the Knight Vestal Covenant may leave this unit and join another unit from the same Detachment they were selected as part of.</description>
+            <rule id="e181-6e76-57bc-4118" name="Vigilant Covenant" publicationId="9fab-fea7-a93c-2074" page="145" hidden="false">
+              <description>A Vigilant Covenant is selected as any other unit, using up a single Force Organisation slot and bought in the same manner. However, before the first turn begins, all models in a Vigilant Covenant must be assigned to another unit from another unit from the same detachment if the army they were selected as part of. Knight Vestals may only be assigned to units entirely composed of models with the Infantry Unit Type and the Silent Sisterhood (X) Special Rule.
+
+
+A Knight Vestal cannot be assigned to any unit that includes one or more models with the Independent Character Special Rule or Unique Unit Sub-type (but such models may join a unit that includes a Knight Vestal as normal during either deployment or any following turn).
+
+
+No more than one Knight Vestal may be assigned to any given unit. Once assigned to a unit, the Knight Vestal is considered part of that unit and may not leave under any circumstances - if that unit is removed as a casualty then the Knight Vestal is removed as well. In battles using Victory Points, no Victory Points are ever scored for removing a Knight Vestal as a casualty. When assigned to a unit, a Knight Vestal gains all of the Special Rules (with the exception of those that specifically forbid it, such as the Bitter Duty Special Rule) and Unit Sub-types listed for the unit to which it is attached, but does not gain access to any additional wargear options available to the unit to which it is assigned</description>
             </rule>
           </rules>
           <infoLinks>
@@ -3483,18 +3488,18 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c8d-bd9f-0e48-feee" type="max"/>
           </constraints>
           <profiles>
-            <profile id="46f0-6456-36f2-c78a" name="Eradicator Mistress" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="46f0-6456-36f2-c78a" name="Eradicator Mistress" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="145">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infanty (Light, Anathema, Character)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                 <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                 <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
                 <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
                 <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
-                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
+                <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">9</characteristic>
                 <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
               </characteristics>
             </profile>
@@ -3637,6 +3642,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1450-a1a7-6cc4-5cc6" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink import="true" name="Voidsheen Cloak" hidden="false" id="4837-f2cd-f031-7895" collective="false" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c2ff-2efe-b066-2e7c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fdef-9590-ec5c-73b5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -3660,13 +3671,13 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infanty (Light, Anathema)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
                     <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
                     <characteristic name="S" typeId="e478-41d4-a092-48a8">3</characteristic>
                     <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">3</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">1</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
                 </profile>
@@ -3696,9 +3707,15 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09b9-6e1e-ce49-8a1f" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink import="true" name="Voidsheen Cloak" hidden="false" id="e346-9054-8d00-144e" collective="false" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b6df-90d7-df72-ba8f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1467-3a33-5d8d-377f" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <categoryLinks>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="1a0b-cda2-422b-a4ad" name="Light Sub-type" primary="false"/>
@@ -3787,12 +3804,18 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cf0-ff7e-9106-0aff" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink import="true" name="Voidsheen Cloak" hidden="false" id="b019-c05d-15a4-a0a4" collective="false" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d6d6-dbc-e337-51b6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5201-5df0-158f-4fb6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
               <infoLinks>
-                <infoLink id="c4f7-365a-e592-0f7e" name="Eradicator" targetId="1a1e-a7fd-7c32-3f56" type="profile"/>
+                <infoLink id="c4f7-365a-e592-0f7e" name="Eradicator" targetId="1a1e-a7fd-7c32-3f56" type="profile" publicationId="9fab-fea7-a93c-2074" page="145"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink targetId="bff2-ae16-74a8-8712" id="96df-1558-4545-b990" name="Light Sub-type" primary="false"/>
@@ -3815,7 +3838,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="a2df-539a-6cc6-92a3" name="Prosecutor Cadre" publicationId="15a4-fc68-502d-48a9" hidden="false" collective="false" import="true" type="unit">
@@ -4498,7 +4521,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0431-a02c-03b4-f114" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="e14d-0b1e-4185-fb25" name="Silent Sisterhood (Chamber of Obivion)" hidden="false" collective="false" import="true" targetId="7856-71cb-a1fb-bc43" type="selectionEntry">
+        <entryLink id="e14d-0b1e-4185-fb25" name="Silent Sisterhood (Chamber of Vigilance)" hidden="false" collective="false" import="true" targetId="7b50-6b5d-e6f9-420b" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="145">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3273-8e39-f86d-6cbb" type="min"/>
           </constraints>
@@ -4586,7 +4609,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 <entryLink id="3f76-eeb7-d812-b12a" name="Close Combat Weapon" hidden="false" collective="false" import="true" targetId="3d50-2f85-06ff-6aee" type="selectionEntry"/>
                 <entryLink id="d046-533d-3b5e-fdef" name="Execution Blade" hidden="false" collective="false" import="true" targetId="adc6-3519-204d-2921" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -4882,7 +4905,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 </infoLink>
                 <infoLink id="a9a8-91ea-7ca1-60ba" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rage (1)"/>
+                    <modifier type="set" field="name" value="Rage (2)"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
@@ -5019,7 +5042,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 </infoLink>
                 <infoLink id="6bf1-885e-f51a-4e36" name="Rage (X)" hidden="false" targetId="564d-3550-ae44-2f99" type="rule">
                   <modifiers>
-                    <modifier type="set" field="name" value="Rage (1)"/>
+                    <modifier type="set" field="name" value="Rage (2)"/>
                   </modifiers>
                 </infoLink>
                 <infoLink id="1948-674a-38d9-e6d3" name="Cyber Felidae" targetId="fa66-ffb8-0dad-a440" type="profile"/>
@@ -5110,7 +5133,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="45"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="b739-d90c-49d7-903c" name="Firebrand Cadre" publicationId="15a4-fc68-502d-48a9" hidden="false" collective="false" import="true" type="unit">
@@ -6218,6 +6241,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <repeat field="selections" scope="d748-5878-98f6-b592" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
+                <modifier type="set" value="Adrathic Destructor w/ Suspensor Web" field="name"/>
               </modifiers>
             </entryLink>
             <entryLink id="31c3-2bd3-2990-6899" name="Vratine Missile Launcher" hidden="false" collective="false" import="true" targetId="0ee4-7a2e-804a-a934" type="selectionEntry">
@@ -6228,6 +6252,19 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                   </repeats>
                 </modifier>
               </modifiers>
+            </entryLink>
+            <entryLink import="true" name="Suspensor Web" hidden="true" id="47f8-34e0-8341-9028" type="selectionEntry" targetId="6472-db7f-08b0-d7c7">
+              <modifiers>
+                <modifier type="set" value="false" field="hidden">
+                  <conditions>
+                    <condition type="greaterThan" value="0" field="selections" scope="parent" childId="8339-4003-fe88-b536" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3523-3f04-fd70-33d6" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1941-ef8a-824e-a656" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
@@ -6561,13 +6598,21 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
       <profiles>
         <profile id="176e-afc8-202c-dfa6" name="Erinyes Jetbike" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">An Erinyes jetbike has a snare cannon and sets the Unit Type of any model with an Erinyes jetbike to Cavalry (Antigrav) (The model keeps any additional Sub-types it may have). In addition, a model with an Erinyes jetbike gains the Shrouded (6+) special rule on any turn in which it has moved, or the Shrouded (5+) special rule if it has Run in that turn.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">An Erinyes jetbike has a snare cannon and sets the Unit Type of any model with an Erinyes jetbike to Cavalry (Antigrav) (The model keeps any additional Sub-types it may have). In addition, a model with an Erinyes jetbike gains the Shrouded (6+) special rule on any turn in which it has moved, or the Shrouded (5+) special rule if it has Run in that turn. In addition, any model equipped with an Erinyes Jetbike sets its Movement Characteristic to 18”, and gains the Skilled Rider and Battle-Hardened (1) Special Rules.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Skilled Rider" hidden="false" id="33db-75ce-df02-9d14" type="rule" targetId="89cc-21e0-bee2-6a89"/>
+        <infoLink name="Battle-Hardened (X)" hidden="false" id="3dbd-37c4-796f-19ab" type="rule" targetId="5c3b-ed0b-4ad0-d547">
+          <modifiers>
+            <modifier type="set" value="Battle-Hardened (1)" field="name"/>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="8404-1251-6f3a-70bd" name="Vratine Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntries>
@@ -6880,7 +6925,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d732-3008-0d8e-c711" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="4249-7465-c325-e974" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
+            <entryLink id="4249-7465-c325-e974" name="Gravis Melta Cannon" hidden="false" collective="false" import="true" targetId="ef6c-f656-171a-03e1" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="145">
               <modifiers>
                 <modifier type="set" value="Hull (Front) Mounted multi-melta" field="name"/>
               </modifiers>
@@ -7043,7 +7088,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
             <infoLink id="5723-b67b-9c61-4c71" name="Loyalist" hidden="false" targetId="d1de-a45d-2b9b-c878" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="212f-b3d9-ce1b-7664" name="1) Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="3785-36e1-67cc-e4fe">
+            <selectionEntryGroup id="212f-b3d9-ce1b-7664" name="1) Select any Two Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="3785-36e1-67cc-e4fe">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d498-1991-0083-fea4" type="max"/>
               </constraints>
@@ -7279,122 +7324,115 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="8dd9-c968-38a1-7dcf" name="2) Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ad1-0048-0f7c-df8b">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="825b-68a7-27ed-70c3" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="6ad1-0048-0f7c-df8b" name="Bolt Pistol" hidden="false" collective="false" import="true" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Bolt Pistol">
-                      <conditions>
-                        <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
+                <entryLink import="true" name="Archaeotech Pistol" hidden="false" id="e629-1d86-1f51-3260" collective="false" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f46-859d-98b4-f322" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e23-cd35-9714-d6cb" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="8ffd-a208-2cef-0a38" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                </entryLink>
-                <entryLink id="1e97-9e9a-38a9-3789" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Hand Flamer">
-                      <conditions>
-                        <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c403-0597-8f27-fdfe" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="55f7-708b-7631-40d0" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
-                </entryLink>
-                <entryLink id="baad-ca47-fc42-7b04" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Needle Pistol">
-                      <conditions>
-                        <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cb3-37f6-a376-9f2d" type="max"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink id="cfba-e2c3-4eab-af14" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="true">
-                          <conditions>
-                            <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                    <cost name="Pts" hidden="false" id="4506-2b40-5ca-cd88" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
-                <entryLink id="1a58-af9f-8f39-311d" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                <entryLink import="true" name="Bolt Pistol" hidden="false" id="6ad1-0048-0f7c-df8b" collective="false" targetId="e5ae-6872-37aa-8600" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Master-crafted Plasma Pistol">
+                    <modifier type="set" value="Master-crafted Bolt Pistol" field="name">
                       <conditions>
-                        <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
+                        <condition type="equalTo" value="1" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                       </conditions>
                     </modifier>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be5-3b99-a65e-3ec9" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7f46-859d-98b4-f322" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                   <infoLinks>
-                    <infoLink id="898d-0c6b-a074-6b3d" name="Master-crafted" hidden="false" targetId="6de0-55b0-bf21-48b9" type="rule">
+                    <infoLink name="Master-crafted" hidden="false" id="8ffd-a208-2cef-0a38" targetId="6de0-55b0-bf21-48b9" type="rule">
                       <modifiers>
-                        <modifier type="set" field="hidden" value="true">
+                        <modifier type="set" value="true" field="hidden">
                           <conditions>
-                            <condition field="selections" scope="a46b-9c18-a39f-0ca8" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="72cc-351b-909a-9129" type="equalTo"/>
+                            <condition type="equalTo" value="0" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink import="true" name="Hand Flamer" hidden="false" id="1e97-9e9a-38a9-3789" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-crafted Hand Flamer" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c403-0597-8f27-fdfe" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink name="Master-crafted" hidden="false" id="55f7-708b-7631-40d0" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                </entryLink>
+                <entryLink import="true" name="Needle Pistol" hidden="false" id="baad-ca47-fc42-7b04" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-crafted Needle Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6cb3-37f6-a376-9f2d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink name="Master-crafted" hidden="false" id="cfba-e2c3-4eab-af14" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" hidden="false" id="5706-886-b9c3-38b8" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
-                <entryLink id="e629-1d86-1f51-3260" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                <entryLink import="true" name="Plasma Pistol" hidden="false" id="1a58-af9f-8f39-311d" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-crafted Plasma Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e23-cd35-9714-d6cb" type="max"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7be5-3b99-a65e-3ec9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
+                  <infoLinks>
+                    <infoLink name="Master-crafted" hidden="false" id="898d-0c6b-a074-6b3d" targetId="6de0-55b0-bf21-48b9" type="rule">
+                      <modifiers>
+                        <modifier type="set" value="true" field="hidden">
+                          <conditions>
+                            <condition type="equalTo" value="0" field="selections" scope="a46b-9c18-a39f-0ca8" childId="72cc-351b-909a-9129" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" hidden="false" id="84e3-7005-404a-514b" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="6dc6-a07f-3e78-f3d1" name="3) May upgrade any one weapon to have the Master-crafted" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="6dc6-a07f-3e78-f3d1" name="2) May upgrade any one weapon to have the Master-crafted" hidden="false" collective="false" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ac2-7570-7db9-baec" type="max"/>
               </constraints>
@@ -7546,7 +7584,7 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">4</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">2</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
-                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                    <characteristic name="Save" typeId="e593-6b3c-f169-04f0">2+</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7587,10 +7625,10 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2482-6990-f46b-0ad6" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="5598-eee6-c207-cca7" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="2336-68cc-2821-cbfd" type="selectionEntry" targetId="9196-3af7-9545-e62b">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="310d-0a23-4353-daa2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f34-6f1a-145b-37b5" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="63e1-601-344b-4f09" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="30f6-ba28-665d-2328" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -7627,12 +7665,6 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
-                <entryLink id="0cea-c0aa-5664-a898" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="438c-6c3c-2145-8e97" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4aaf-b1a2-38f7-6cae" type="min"/>
-                  </constraints>
-                </entryLink>
                 <entryLink id="65b7-ef5f-6ec1-f178" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1819-5138-ed03-c7ca" type="max"/>
@@ -7655,6 +7687,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f7c-2e2a-0aff-037a" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4057-af3d-8cd0-8cb5" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="d981-508e-3a43-b57d" type="selectionEntry" targetId="9196-3af7-9545-e62b">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d519-c117-35d5-f7e5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5b9c-56ee-bdb5-9446" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -7691,12 +7729,6 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
                 </entryLink>
-                <entryLink id="cb26-2997-e94c-d698" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b540-a7b7-512d-d072" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67da-0a4f-ffad-64bd" type="min"/>
-                  </constraints>
-                </entryLink>
                 <entryLink id="e29d-acd0-44ac-d5df" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29e6-0ba1-92d6-557e" type="max"/>
@@ -7719,6 +7751,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f75-2fee-be0a-8da9" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d10-1d7c-9996-830a" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="c958-101b-4360-1c6f" type="selectionEntry" targetId="9196-3af7-9545-e62b">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65f7-9eb-7cbc-413e" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="866-69be-80c6-986c" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -7824,12 +7862,6 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="5b45-adfb-af67-bbca" name="Vratine Armour" hidden="false" collective="false" import="true" targetId="91c6-82e2-3c3e-fe76" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d073-a30c-a29c-cc62" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c914-68b0-e44d-c340" type="min"/>
-                  </constraints>
-                </entryLink>
                 <entryLink id="a548-192f-125c-562c" name="Voidsheen Cloak" hidden="false" collective="false" import="true" targetId="9449-eb87-30c1-43c0" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b824-5372-80c3-77eb" type="max"/>
@@ -7852,6 +7884,12 @@ In addition, the Leadership Characteristic of a model with the Anathema Unit Sub
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b35-32ca-f8a7-4d60" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a0f-1251-00e4-7163" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Artificer Armour" hidden="false" id="12ce-40d2-2bc4-2b81" type="selectionEntry" targetId="9196-3af7-9545-e62b">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c0e6-3b7e-617-3b5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a9b6-8228-744a-5caf" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>

--- a/2022 - LI - Sisters Of Silence.cat
+++ b/2022 - LI - Sisters Of Silence.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ee0f-23d3-8682-53c4" name="LI - Sisters of Silence" revision="2020" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="ee0f-23d3-8682-53c4" name="LI - Sisters of Silence" revision="2021" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="b760-8313-847f-1afa" name="Obivion HQ" hidden="false"/>
     <categoryEntry id="a9b6-f66f-e8ee-553e" name="Judgement HQ" hidden="false"/>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -8942,7 +8942,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2918-e98d-0ab1-811b" name="Carnodon Strike Squadron" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="2918-e98d-0ab1-811b" name="Carnodon Strike Squadron" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="150">
       <categoryLinks>
         <categoryLink id="684c-8ae7-c5cb-3acc" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="165d-ca07-dcb-e3fd" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -9043,13 +9043,16 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7da4-5e9b-ba18-c423" type="min"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a40b-777d-667c-84ed" type="max"/>
                   </constraints>
+                  <modifiers>
+                    <modifier type="set" value="Turret Mounted Volkite Culverin" field="name"/>
+                  </modifiers>
                 </entryLink>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a959-83a9-88ed-8deb" name="Turret Mounted Twin-linked Autocannon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="a959-83a9-88ed-8deb" name="Turret Mounted Gravis Autocannon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5">
                   <repeats>
@@ -9058,24 +9061,21 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </modifier>
               </modifiers>
               <entryLinks>
-                <entryLink id="d045-b197-7d17-2ab0" name="Autocannon" hidden="false" collective="false" import="true" targetId="56b3-de09-9fea-deb6" type="selectionEntry">
+                <entryLink import="true" name="Gravis Autocannon" hidden="false" id="5f6e-b57b-b2f1-2b3c" type="selectionEntry" targetId="8a23-e57d-b4a8-14a9">
                   <modifiers>
-                    <modifier type="set" field="name" value="Turret Mounted Twin-linked Autocannon"/>
+                    <modifier type="set" value="Turret Mounted Gravis Autocannon" field="name"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9eb6-2610-e578-a0f1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b0e6-8e6d-fbc9-9f23" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="fc9e-ab5c-d556-bdc3" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="false" id="23e1-2e63-3c67-5d81" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="a8ee-1db6-8c93-d3c0" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-                  </infoLinks>
                 </entryLink>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="9f5d-2c09-e44f-6627" name="Turret Mounted Twin-linked Lascannon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="9f5d-2c09-e44f-6627" name="Turret Mounted Gravis Lascannon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20">
                   <repeats>
@@ -9084,13 +9084,13 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </modifier>
               </modifiers>
               <entryLinks>
-                <entryLink id="d67e-2040-07d8-3877" name="Twin-linked Lascannon" hidden="false" collective="false" import="true" targetId="3adf-7150-9ee6-b2de" type="selectionEntry">
+                <entryLink import="true" name="Gravis Lascannon" hidden="false" id="4d4f-79f2-6dbb-8e80" type="selectionEntry" targetId="1fe0-7c96-5200-0e39">
                   <modifiers>
-                    <modifier type="set" field="name" value="Turret Mounted Twin-linked Lascannon"/>
+                    <modifier type="set" value="Turret Mounted Gravis Lascannon" field="name"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e42-5c84-41b8-b450" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="affb-611e-8ddc-1bfd" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="5e98-3b09-fe7d-c16b" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="false" id="e2fe-a7ce-88ab-c291" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -9098,19 +9098,16 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="d822-797e-d15a-435a" name="Turret Mounted Twin-linked Multi-Laser" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d822-797e-d15a-435a" name="Turret Mounted Gravis Multi-Laser" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="6dd4-29d5-5668-7a3b" name="Multi-Laser" hidden="false" collective="false" import="true" targetId="003b-af4b-0094-f5c3" type="selectionEntry">
+                <entryLink import="true" name="Gravis Multi-Laser" hidden="false" id="f050-1043-b876-44e8" type="selectionEntry" targetId="9938-d8d4-e0cc-b883">
                   <modifiers>
-                    <modifier type="set" field="name" value="Turret Mounted Twin-linked Multi-Laser"/>
+                    <modifier type="set" value="Turret Mounted Gravis Multi-Laser" field="name"/>
                   </modifiers>
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a01-bd31-4054-ec99" type="max"/>
-                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b24a-bce6-1949-c6e6" type="min"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="7256-5d62-cfdc-bdcd" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="false" id="2ce9-583d-4770-fda1" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="3056-bb78-b0b5-1ad7" name="Twin-linked" hidden="false" targetId="8542-ee9d-e2fa-52fe" type="rule"/>
-                  </infoLinks>
                 </entryLink>
               </entryLinks>
               <costs>
@@ -9159,7 +9156,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             </selectionEntry>
             <selectionEntry id="5f07-95b6-fbff-d53e" name="Two Sponson Mounted Heavy Bolter" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10">
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="0">
                   <repeats>
                     <repeat field="selections" scope="2918-e98d-0ab1-811b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e067-3e89-30e3-aed8" repeats="1" roundUp="false"/>
                   </repeats>
@@ -9182,7 +9179,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             </selectionEntry>
             <selectionEntry id="3e04-7aeb-959d-61ef" name="Two Sponson Mounted Lascannons" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="20">
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="15">
                   <repeats>
                     <repeat field="selections" scope="2918-e98d-0ab1-811b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e067-3e89-30e3-aed8" repeats="1" roundUp="false"/>
                   </repeats>
@@ -9205,7 +9202,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             </selectionEntry>
             <selectionEntry id="25d6-a17a-5db1-6969" name="Two Sponson Mounted Autocannon" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10">
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="5">
                   <repeats>
                     <repeat field="selections" scope="2918-e98d-0ab1-811b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e067-3e89-30e3-aed8" repeats="1" roundUp="false"/>
                   </repeats>
@@ -9228,7 +9225,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             </selectionEntry>
             <selectionEntry id="32ae-5000-8b0a-19ef" name="Two Sponson Mounted Multi-lasers" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
-                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="10">
+                <modifier type="increment" field="d2ee-04cb-5f8a-2642" value="0">
                   <repeats>
                     <repeat field="selections" scope="2918-e98d-0ab1-811b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e067-3e89-30e3-aed8" repeats="1" roundUp="false"/>
                   </repeats>
@@ -9538,7 +9535,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                   <rules>
                     <rule id="38c8-414f-35c2-bf17" name="Field Repair (X)" hidden="false">
                       <modifiers>
-                        <modifier type="set" field="name" value="Field Repair (5+)"/>
+                        <modifier type="set" field="name" value="Field Repair (4+)">
+                          <comment>Panoptica 150</comment>
+                        </modifier>
                       </modifiers>
                       <description>If a model with the Field Repair (X) special rule is within 3&quot; of one or more friendly damaged Vehicles during the Shooting phase, they can attempt to Repair one damaged Vehicle instead of firing all weapons or using any other abilities that would be used instead of making a Shooting Attack. To attempt a Repair, roll a D6. If the result is equal to or more than the value listed in brackets as part of this special rule then one of the following options may be applied to any one
 Vehicle model within 3&quot; of the Solar Auxilia Trojan Support Vehicle:
@@ -9629,7 +9628,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                 <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6934-3380-6bdf-68a3" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="12a6-af4b-e892-590c" name="Thunderer Siege Tank" hidden="false" collective="false" import="true" type="model">
+                <selectionEntry id="12a6-af4b-e892-590c" name="Thunderer Siege Tank" hidden="false" collective="false" import="true" type="model" publicationId="9fab-fea7-a93c-2074" page="150">
                   <constraints>
                     <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfc1-024b-9260-2f41" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cb9-a6a8-95b6-4df3" type="min"/>
@@ -9739,7 +9738,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                   </costs>
                 </selectionEntry>
               </selectionEntries>
@@ -9837,7 +9836,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                   </costs>
                   <selectionEntries>
                     <selectionEntry type="upgrade" import="true" name="Proteus Laser Destroyer" hidden="false" id="6b62-613b-1dd7-2d50">
@@ -9846,12 +9845,12 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3037-2971-417b-29d5-max" includeChildSelections="false"/>
                       </constraints>
                       <profiles>
-                        <profile name="Proteus Laser Destroyer" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="be6b-c2ce-7ff4-af70">
+                        <profile name="Proteus Laser Destroyer" typeId="1a1a-e592-2849-a5c0" typeName="Weapon" hidden="false" id="be6b-c2ce-7ff4-af70" publicationId="9fab-fea7-a93c-2074" page="172">
                           <characteristics>
                             <characteristic name="Range" typeId="95ba-cda7-b831-6066">36&quot;</characteristic>
                             <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">9</characteristic>
                             <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Heavy 2, Twin-linked, Exoshock (6+), Gets Hot</characteristic>
+                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 3, Twin-linked, Exoshock (6+), Sunder, Gets Hot</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -9863,6 +9862,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                           </modifiers>
                         </infoLink>
                         <infoLink name="Gets Hot" hidden="false" id="d96b-f5f2-2a89-af93" type="rule" targetId="679f-9d97-5ace-a652"/>
+                        <infoLink name="Sunder" hidden="false" id="cffb-451b-c28a-64d9" type="rule" targetId="20e2-75cf-bc16-cd8f"/>
                       </infoLinks>
                       <modifiers>
                         <modifier type="set" value="Centreline (Front) Mounted Proteus Laser Destroyer" field="name"/>
@@ -9930,7 +9930,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                 </entryLink>
                 <entryLink id="120b-e5ac-6dfc-aed7" name="Hunter-Killer Missile" hidden="false" collective="false" import="true" targetId="1bf8-72f8-c331-6900" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="name" value="Hull (Front) Mounted hunter-killer missile"/>
+                    <modifier type="set" field="name" value="Hull (Rear) Mounted Hunter-Killer Missile">
+                      <comment>Panoptica 150</comment>
+                    </modifier>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a153-39e5-ec1f-597f" type="max"/>
@@ -9943,9 +9945,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="7e5e-e884-86c6-16e7" name="Earthshaker cannon" hidden="false" collective="false" import="true" targetId="cc2e-df5f-1778-29d8" type="selectionEntry">
+            <entryLink id="7e5e-e884-86c6-16e7" name="Earthshaker Battery" hidden="false" collective="false" import="true" targetId="1815-c1cd-170-1d3" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="150">
               <modifiers>
-                <modifier type="set" field="name" value="Hull Centreline (Rear) Mounted twin-linked Earthshaker cannon"/>
+                <modifier type="set" field="name" value="Hull Centreline (Rear) Mounted Earthshaker Battery"/>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bd0-da2f-cfc6-1ef9" type="min"/>
@@ -9974,8 +9976,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
     <selectionEntry id="e59c-1b65-8de1-4490" name="Macharius Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="3cf6-cfb2-9cec-19aa" name="Vehicle Unit:" hidden="false" targetId="23eb-0b9e-0857-e965" primary="false"/>
-        <categoryLink id="0894-5a2a-e649-9e11" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
-        <categoryLink id="ef5d-7e4a-3f44-2c74" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink targetId="7031-469a-1aeb-eab0" id="87d6-f9d4-628a-f39f" primary="true" name="Heavy Support:"/>
+        <categoryLink targetId="9b0d-738c-10e4-4ec1" id="74f7-a399-d3ad-183c" primary="false" name="Reinforced Sub-type:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="83fd-3959-0a1c-1815" name="Macharius Heavy Tank" hidden="false" collective="false" import="true" type="model">
@@ -10000,7 +10002,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           </profiles>
           <categoryLinks>
             <categoryLink id="47e4-9cd8-d66e-2c84" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
-            <categoryLink targetId="7381-1130-ca6e-1806" id="123c-7159-411c-8956" name="Super-heavy Sub-type" primary="false"/>
+            <categoryLink targetId="9b0d-738c-10e4-4ec1" id="a381-66a2-5e65-6094" primary="false" name="Reinforced Sub-type:"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="1293-cf52-b3db-1611" name="2) Pintle mounted Weapon:" hidden="false" collective="false" import="true">
@@ -10096,12 +10098,16 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="280"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="235"/>
           </costs>
+          <infoLinks>
+            <infoLink name="Independent Fire Control" hidden="false" id="beea-bb7-2149-caf0" type="rule" targetId="64ca-719e-b563-e3df"/>
+            <infoLink name="Armoured Superstructure" hidden="false" id="423-21c7-217d-9414" type="rule" targetId="fde9-c473-d6c9-0e69"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
       <selectionEntryGroups>
         <selectionEntryGroup name="1) Main Cannon" hidden="false" id="f63b-b35f-38f5-9de2" collective="false" import="true" defaultSelectionEntryId="4530-f4f8-699a-99d9">
@@ -10129,14 +10135,14 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntry>
-    <selectionEntry id="7331-a4a7-8e69-c55e" name="Stormblade" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="7331-a4a7-8e69-c55e" name="Stormblade" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="150">
       <profiles>
         <profile id="68c0-0be5-9796-c78a" name="Stormblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
@@ -10233,19 +10239,28 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c81-4dc6-673b-4e5a" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Heavy Bolter" hidden="false" id="1c5f-f116-e4e1-1420" collective="false" targetId="07fd-c24a-9235-4206" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" value="Hull (Front) Mounted Heavy Bolter" field="name"/>
+          </modifiers>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b9ee-768c-26df-6f56" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ce1-96e-dc83-fc41" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="475"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1c10-5772-2e27-1e51" name="Baneblade" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="1c10-5772-2e27-1e51" name="Baneblade" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="150">
       <profiles>
         <profile id="2482-9109-93f4-a892" name="Baneblade" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
@@ -10371,21 +10386,21 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7bb3-2416-aaca-8e40" name="Banehammer" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="7bb3-2416-aaca-8e40" name="Banehammer" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="151">
       <profiles>
         <profile id="0068-847e-a08c-f19f" name="Banehammer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
-            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">10</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">22</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">1</characteristic>
           </characteristics>
         </profile>
@@ -10395,6 +10410,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="e4ad-1c54-0ec3-d2e9" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="037c-b14a-bd4d-4165" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ab12-4d4c-d43a-85ae" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
+        <categoryLink targetId="7b0a-a743-a8da-3a39" id="5a2c-647b-53ce-f3dc" primary="false" name="Transport Sub-type:"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="a69e-ee27-cecc-5be5" name="4) May take:" hidden="false" collective="false" import="true">
@@ -10489,22 +10505,31 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="475"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Tank Desant" hidden="false" id="b8f6-7592-994-5c26" type="rule" targetId="f690-0d4f-dae7-d730"/>
+        <infoLink name="Assault Vehicle" hidden="false" id="896b-3c86-1185-edca" type="rule" targetId="aa61-11f6-2bb5-7c0e"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="2bae-aaa9-9840-e2eb" name="Stormlord" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="2115-d799-e0c7-dee4" name="Stormlord" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="2115-d799-e0c7-dee4" name="Stormlord" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="151">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy, Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
-            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">10</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">32</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Stormlord Access Ramp" hidden="false" id="a099-1fb3-15c0-67b3" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item" publicationId="9fab-fea7-a93c-2074" page="151">
+          <characteristics>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A Solar Auxilia Stormlord has one Access Point at the rear of the hull.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -10597,19 +10622,28 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a1e-412f-fd41-17a4" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Vulcan Mega-Bolter" hidden="false" id="a833-7b-435d-237e" type="selectionEntry" targetId="b953-83d7-6cc1-5695">
+          <modifiers>
+            <modifier type="set" value="Turret Mounted Vulcan Mega-Bolter" field="name"/>
+          </modifiers>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Tank Desant" hidden="false" id="c6ea-617e-796b-2c0d" type="rule" targetId="f690-0d4f-dae7-d730"/>
+        <infoLink name="Assault Vehicle" hidden="false" id="3ac3-44e0-8973-d0ae" type="rule" targetId="aa61-11f6-2bb5-7c0e"/>
+      </infoLinks>
     </selectionEntry>
-    <selectionEntry id="4713-c9ee-2c57-9457" name="Shadowsword" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="4713-c9ee-2c57-9457" name="Shadowsword" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="151">
       <profiles>
         <profile id="947b-e923-5118-4418" name="Shadowsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
@@ -10716,17 +10750,17 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="475"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3d0b-9f37-cd30-0db7" name="Stormsword" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="3d0b-9f37-cd30-0db7" name="Stormsword" hidden="false" collective="false" import="true" type="unit" publicationId="9fab-fea7-a93c-2074" page="151">
       <profiles>
         <profile id="26c0-cec5-acdc-0e3a" name="Stormsword" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
@@ -10845,7 +10879,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="650"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="475"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2d13-ea6e-e48d-f352" name="Praetor Armoured Assault Launcher" hidden="false" collective="false" import="true" type="unit">
@@ -10870,37 +10904,6 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         <categoryLink id="68b3-c9fb-8111-8174" name="Super-heavy Sub-type" hidden="false" targetId="7381-1130-ca6e-1806" primary="false"/>
         <categoryLink id="ee2c-9ed9-6d30-f2f7" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="aae7-cba1-91ac-8636" name="Praetor Launcher" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd5-8266-e417-0882" type="min"/>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3c9-e405-6ac5-1e79" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="52a7-5459-a9c2-6561" name="Praetor Launcher" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="95ba-cda7-b831-6066">72&quot;</characteristic>
-                <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
-                <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Barrage, Massive Blast (7&quot;), Pinning, Rending (6+)</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="63ca-7f5c-c71c-9f53" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
-              <modifiers>
-                <modifier type="set" field="name" value="Rending (+6)"/>
-              </modifiers>
-            </infoLink>
-            <infoLink id="7797-a84c-7d76-dc64" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
-            <infoLink id="e67d-23f0-37cb-d3c2" name="Pinning" hidden="false" targetId="1c96-205c-59a0-3cf2" type="rule"/>
-            <infoLink id="c6d7-6678-3236-f99b" name="Barrage" hidden="false" targetId="7255-b5ee-c3f4-3037" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="d40b-b2ee-537f-aa0e" name="2) May take:" hidden="false" collective="false" import="true">
           <entryLinks>
@@ -10961,8 +10964,11 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="500"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="450"/>
       </costs>
+      <entryLinks>
+        <entryLink import="true" name="Praetor Launcher" hidden="false" id="aae7-cba1-91ac-8636" type="selectionEntry" targetId="c123-e9f7-ee20-c4f9"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="8cec-2913-77a0-c4e4" name="Crassus Armoured Assault Transport" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
@@ -10988,8 +10994,8 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                 <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">12</characteristic>
                 <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
                 <characteristic name="HP" typeId="a76c-83b1-602f-9e62">8</characteristic>
-                <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">35</characteristic>
-                <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point at the rear of the hull</characteristic>
+                <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">48</characteristic>
+                <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point at the Rear of the Hull</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -11061,6 +11067,9 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
             <categoryLink targetId="7381-1130-ca6e-1806" id="3a1c-3747-4b37-9839" name="Super-heavy Sub-type" primary="false"/>
             <categoryLink targetId="7b0a-a743-a8da-3a39" id="d8ed-cff9-47b3-bda9" name="Transport Sub-type" primary="false"/>
           </categoryLinks>
+          <infoLinks>
+            <infoLink name="Transport Bay" hidden="false" id="3a0a-48dc-a649-bba7" type="rule" targetId="0662-8b8d-38e8-60f8"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -11087,18 +11096,18 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34cb-260c-3f16-61d4" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="d976-3125-68a5-8ac2" name="Artillery Platform" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                    <profile id="d976-3125-68a5-8ac2" name="Artillery Platform" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="151">
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Static Artillery, Heavy)</characteristic>
                         <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
+                        <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">-</characteristic>
                         <characteristic name="BS" typeId="74ae-c840-0036-d244">4</characteristic>
-                        <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
-                        <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
-                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">-</characteristic>
+                        <characteristic name="S" typeId="e478-41d4-a092-48a8">7</characteristic>
+                        <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">7</characteristic>
+                        <characteristic name="W" typeId="57ee-1126-32a9-5672">4</characteristic>
+                        <characteristic name="I" typeId="62d3-22d7-2d49-52dc">-</characteristic>
+                        <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">-</characteristic>
+                        <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
                         <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                       </characteristics>
                     </profile>
@@ -11110,6 +11119,12 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                   </rules>
                   <infoLinks>
                     <infoLink id="cd55-2970-90c8-cea9" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+                    <infoLink name="Bulky (X)" hidden="false" id="5b11-94e3-fa51-a03b" type="rule" targetId="676c-7b75-4b6f-9405">
+                      <modifiers>
+                        <modifier type="set" value="Bulky (5)" field="name"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink name="Immobile" hidden="false" id="baa3-da0d-b27d-c4f6" type="rule" targetId="a676-e911-8581-8a72"/>
                   </infoLinks>
                   <selectionEntries>
                     <selectionEntry id="a458-d885-c32a-18f1" name="Auxilia Gunners" hidden="false" collective="true" import="true" type="model">
@@ -11130,7 +11145,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
                             <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                             <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
                             <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
-                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -11264,6 +11279,14 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
+              <infoLinks>
+                <infoLink name="Bulky (X)" hidden="false" id="668e-6d11-4ac-ca76" type="rule" targetId="676c-7b75-4b6f-9405">
+                  <modifiers>
+                    <modifier type="set" value="Bulky (5)" field="name"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Immobile" hidden="false" id="34d-cae3-ec64-194a" type="rule" targetId="a676-e911-8581-8a72"/>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -862,104 +862,10 @@
             <infoLink id="e674-1cda-ba3c-0cfb" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="494c-7f28-ee5a-75b4" name="May exchange a Laspistol for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d3cf-77b5-079a-4dbe">
+            <selectionEntryGroup id="060d-d998-a340-70ee" name="May exchange their Laspistol and/or Close Combat Weapon for one of the Following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="506a-61e7-02e4-b9d2">
               <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51c8-bbaa-36ad-bfc6" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad2b-2890-95b2-fab7" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="d3cf-77b5-079a-4dbe" name="Laspistol" hidden="false" collective="false" import="true" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Laspistol">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink id="2a22-15ca-5d08-71ae" name="Needle Pistol" hidden="false" collective="false" import="true" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Needle Pistol">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="af99-1a62-f693-cb3a" name="Hand Flamer" hidden="false" collective="false" import="true" targetId="e337-adf4-a11f-0280" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Hand Flamer">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="7c18-0383-5ebe-bf0f" name="Volkite Serpenta" hidden="false" collective="false" import="true" targetId="d535-1da8-290d-69a6" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Volkite Serpenta">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="a58f-8088-29db-5b91" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Plasma Pistol">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="c0a6-a24a-54f4-7ee4" name="Archaeotech Pistol" hidden="false" collective="false" import="true" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="0418-a453-19d9-0cf5" name="Blast Pistol" hidden="false" collective="false" import="true" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Blast Pistol">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="dec0-ab2a-7634-c289" name="Inferno Pistol" hidden="false" collective="false" import="true" targetId="3f00-1930-8fcb-41c5" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Master-Crafted Inferno Pistol">
-                      <conditions>
-                        <condition field="selections" scope="3e04-d00a-bb4a-5f72" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8a84-4890-8103-289c" type="equalTo"/>
-                      </conditions>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="060d-d998-a340-70ee" name="May exchange a Close Combat Weapon for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="506a-61e7-02e4-b9d2">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-7c44-1712-6c45" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a5-16d0-6ab1-95a1" type="max"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-7c44-1712-6c45" type="min"/>
+                <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2a5-16d0-6ab1-95a1" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="63de-97e9-14b9-fb86" name="Thunder Hammer" hidden="false" collective="false" import="true" targetId="838c-4002-713d-d7c6" type="selectionEntry">
@@ -1029,6 +935,92 @@
                   </modifiers>
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Archaeotech Pistol" hidden="false" id="c0a6-a24a-54f4-7ee4" collective="false" targetId="c22a-ed4d-af68-bf00" type="selectionEntry">
+                  <costs>
+                    <cost name="Pts" hidden="false" id="aec0-f83a-d6e4-76c4" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Blast Pistol" hidden="false" id="0418-a453-19d9-0cf5" collective="false" targetId="2460-375d-31f4-4bdf" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Blast Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="3c44-5a30-5f7f-2ff2" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Hand Flamer" hidden="false" id="af99-1a62-f693-cb3a" collective="false" targetId="e337-adf4-a11f-0280" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Hand Flamer" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="c333-d5fe-3bdb-e1a9" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Inferno Pistol" hidden="false" id="dec0-ab2a-7634-c289" collective="false" targetId="3f00-1930-8fcb-41c5" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Inferno Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="d45d-8a6d-1924-6606" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Laspistol" hidden="false" id="d3cf-77b5-079a-4dbe" collective="false" targetId="654d-be88-b0a8-7ae5" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Laspistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Needle Pistol" hidden="false" id="2a22-15ca-5d08-71ae" collective="false" targetId="fdd4-06c7-4608-b07f" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Needle Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="a4c2-aec8-3cd0-525a" typeId="d2ee-04cb-5f8a-2642" value="2"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Plasma Pistol" hidden="false" id="a58f-8088-29db-5b91" collective="false" targetId="717f-cf0a-1593-4bd8" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Plasma Pistol" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="88ff-5eec-a029-4fcb" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Volkite Serpenta" hidden="false" id="7c18-0383-5ebe-bf0f" collective="false" targetId="d535-1da8-290d-69a6" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" value="Master-Crafted Volkite Serpenta" field="name">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="3e04-d00a-bb4a-5f72" childId="8a84-4890-8103-289c" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Pts" hidden="false" id="326e-a440-ead1-14fb" typeId="d2ee-04cb-5f8a-2642" value="2"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -1468,6 +1460,7 @@
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d65-99c5-45f8-ea12" type="min"/>
                   </constraints>
                 </entryLink>
+                <entryLink import="true" name="Close Combat Weapon" hidden="false" id="8472-98db-32c6-3b4e" type="selectionEntry" targetId="19ab-4d64-f6a7-9f81"/>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="12"/>
@@ -1830,6 +1823,7 @@
                   </modifiers>
                 </entryLink>
                 <entryLink id="5ecb-a60d-222a-3a4e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ebb-8e01-7d58-9d99" type="selectionEntryGroup"/>
+                <entryLink import="true" name="Close Combat Weapon" hidden="false" id="259e-7cca-f846-ce8f" type="selectionEntry" targetId="3d50-2f85-06ff-6aee"/>
               </entryLinks>
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -2273,6 +2267,9 @@
                 <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d3f-f5fe-4022-ad68" name="Infantry Unit Type" primary="false"/>
                 <categoryLink targetId="0af0-ea84-09d7-2b1f" id="ca2e-b7ba-4dab-9642" name="Close-order Sub-type" primary="false"/>
               </categoryLinks>
+              <infoLinks>
+                <infoLink name="Chosen Warriors" hidden="false" id="acae-287b-ad8b-3bfa" type="rule" targetId="13d1-9270-6539-08ed"/>
+              </infoLinks>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -2698,7 +2695,7 @@
             <selectionEntryGroup id="092d-2397-8f02-c431" name="Veletarii" hidden="false" collective="false" import="true" defaultSelectionEntryId="c39a-711f-3566-712d">
               <constraints>
                 <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1168-de26-e5bc-3a25" type="min"/>
-                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ed-c168-0aa5-e59a" type="max"/>
+                <constraint field="selections" scope="parent" value="14" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47ed-c168-0aa5-e59a" type="max"/>
               </constraints>
               <selectionEntries>
                 <selectionEntry id="0e92-6f2e-8f92-40bf" name="Veletarii w/ Power Sword" hidden="false" collective="false" import="true" type="model">
@@ -3082,7 +3079,7 @@
             <entryLink id="6d79-07e1-b369-3180" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="58"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="18"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="c51e-5dce-2d97-4a99" name="Veletaris Storm Section" hidden="false" collective="false" import="true" type="unit">
@@ -4522,12 +4519,12 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f71-2c3f-0d97-a230" type="max"/>
               </constraints>
               <profiles>
-                <profile id="6573-9a7d-f256-722e" name="Charonite Claws" publicationId="15a4-fc68-502d-48a9" page="150" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                <profile id="6573-9a7d-f256-722e" name="Charonite Claws" publicationId="9fab-fea7-a93c-2074" page="174" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">7</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Rending (6+)</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Two-handed, Rending (6+), Murderous Strike (6+)</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -4536,6 +4533,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <infoLink id="6eed-a41b-73e9-6cd5" name="Rending (X)" hidden="false" targetId="0ac9-fab7-aef3-de1d" type="rule">
                   <modifiers>
                     <modifier type="set" field="name" value="Rending (6+)"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink id="9954-ae94-90d8-b1ca" name="Murderous Strike (X)" hidden="false" targetId="93b9-1454-0e7c-42ae" type="rule">
+                  <modifiers>
+                    <modifier type="set" field="name" value="Murderous Strike (6+)"/>
                   </modifiers>
                 </infoLink>
               </infoLinks>
@@ -4580,7 +4582,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         </modifier>
       </modifiers>
       <profiles>
-        <profile id="c611-60e5-a7e3-c094" name="Aurox Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="c611-60e5-a7e3-c094" name="Aurox Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="146">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">15</characteristic>
@@ -4589,7 +4591,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
-            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">10</characteristic>
+            <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">12</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point on each side of the hull and one at the rear.</characteristic>
           </characteristics>
         </profile>
@@ -4653,7 +4655,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="30"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="496b-a01b-3726-0a44" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="496b-a01b-3726-0a44" name="Dracosan Armoured Transport" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="146">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -4664,10 +4666,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       <profiles>
         <profile id="ae05-0bdd-574e-b386" name="Dracosan Armoured Transport" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
           <modifiers>
-            <modifier type="set" field="0c90-79e2-f768-e547" value="10">
+            <modifier type="set" field="0c90-79e2-f768-e547" value="12">
               <conditions>
                 <condition field="selections" scope="496b-a01b-3726-0a44" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d4a-05a3-1589-915d" type="equalTo"/>
               </conditions>
+              <comment>Panoptica 146</comment>
             </modifier>
           </modifiers>
           <characteristics>
@@ -4695,9 +4698,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           </constraints>
           <entryLinks>
             <entryLink id="a2de-e36e-920f-ed49" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry"/>
-            <entryLink id="0ac0-2320-b38c-ff37" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry">
+            <entryLink id="0ac0-2320-b38c-ff37" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="146">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -4780,7 +4783,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175"/>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5041-9403-02b7-af14" name="Arvus Transport" hidden="false" collective="false" import="true" type="upgrade">
@@ -4826,6 +4829,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c64-2d41-bd11-8125" type="max"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e002-31ec-a834-7e98" type="min"/>
           </constraints>
+        </entryLink>
+        <entryLink import="true" name="Heavy Stubber" hidden="false" id="9337-8dc1-eb04-a788" type="selectionEntry" targetId="f227-a61a-3215-932b" publicationId="9fab-fea7-a93c-2074" page="146">
+          <modifiers>
+            <modifier type="set" value="Hull (Front) Mounted Heavy Stubber" field="name"/>
+          </modifiers>
         </entryLink>
       </entryLinks>
       <costs>
@@ -4926,7 +4934,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
                     <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                     <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">3</characteristic>
-                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">7</characteristic>
+                    <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">8</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
                   </characteristics>
                 </profile>
@@ -5182,7 +5190,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <selectionEntryGroup id="1eaf-bbe0-04a5-22c1" name="Auxilia Veterans" hidden="false" collective="false" import="true" defaultSelectionEntryId="38fa-8a5c-8183-737e">
               <constraints>
                 <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3215-57f3-1211-43fb" type="min"/>
-                <constraint field="selections" scope="parent" value="9" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ac8-ebed-57d9-9346" type="max"/>
+                <constraint field="selections" scope="parent" value="14" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ac8-ebed-57d9-9346" type="max"/>
               </constraints>
               <selectionEntries>
                 <selectionEntry id="38fa-8a5c-8183-737e" name="Auxilia Veteran w/ Lasrifle" hidden="false" collective="false" import="true" type="model">
@@ -5227,7 +5235,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="846b-a82e-4b8d-94d6" name="Infantry Unit Type" primary="false"/>
@@ -5257,7 +5265,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="9"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="7"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="db2d-d153-4567-a527" name="Infantry Unit Type" primary="false"/>
@@ -5288,7 +5296,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4d30-2332-4684-8a69" name="Infantry Unit Type" primary="false"/>
@@ -5319,7 +5327,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="bae6-0272-4b1a-9f0d" name="Infantry Unit Type" primary="false"/>
@@ -5350,7 +5358,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="c113-d488-46c6-a7a9" name="Infantry Unit Type" primary="false"/>
@@ -5381,7 +5389,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="4b89-4817-431d-8c0a" name="Infantry Unit Type" primary="false"/>
@@ -5412,7 +5420,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     </entryLink>
                   </entryLinks>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="8"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="6"/>
                   </costs>
                   <categoryLinks>
                     <categoryLink targetId="8b4f-bfe2-ce7b-f1b1" id="19a3-2c49-42b2-b40f" name="Infantry Unit Type" primary="false"/>
@@ -5445,7 +5453,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <entryLink id="ad70-8d7f-026a-3523" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
           </entryLinks>
           <costs>
-            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="33"/>
+            <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="16"/>
           </costs>
           <categoryLinks>
             <categoryLink name="SA or IM Unit" hidden="false" id="5255-f80d-d455-17e3" targetId="4aca-2849-7f41-0200" primary="false"/>
@@ -6095,7 +6103,10 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       <profiles>
         <profile id="4eaa-b4e5-6a43-c638" name="Command Vox" publicationId="15a4-fc68-502d-48a9" page="152" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any friendly unit that includes at least one model with a command vox may choose to use the Leadership value of any model in a friendly unit with another command vox when making Pinning tests or Morale checks – this includes any friendly units with command voxs that are in Reserves or Embarked on unit with the Vehicle Unit Type. A unit that includes a command vox also offer benefits to friendly units that include a vox interlock (see page 153).</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">Any friendly unit that includes at least one model with a command vox may choose to use the Leadership value of any model in a friendly unit with another command vox when making Pinning tests or Morale checks – this includes any friendly units with command voxs that are in Reserves or Embarked on unit with the Vehicle Unit Type. A unit that includes a command vox also offer benefits to friendly units that include a vox interlock (see page 153).
+
+
+While at least one model with a Command Vox is present on the battlefield and not Embarked in a Vehicle or Building, the Controlling Player may re-roll any Scatter rolls made (whether as part of a weapon attack or the deployment of a model or unit), as long as the model with the Command Vox has line of sight to the unit targeted by the attack or the point chosen as the target of the deployment.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -6597,6 +6608,13 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                             <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
                             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">-</characteristic>
                           </characteristics>
+                          <modifiers>
+                            <modifier type="increment" value="1" field="8d4e-2aea-fffc-d556">
+                              <conditions>
+                                <condition type="atLeast" value="1" field="selections" scope="813c-fa93-375d-5f3e" childId="1d4a-05a3-1589-915d" shared="true" includeChildSelections="true"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
                         </profile>
                       </profiles>
                       <selectionEntryGroups>
@@ -6675,7 +6693,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         </entryLink>
                       </entryLinks>
                       <costs>
-                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="185"/>
+                        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="145"/>
                       </costs>
                       <categoryLinks>
                         <categoryLink targetId="e2b6-b770-784c-9e95" id="5c0b-faa9-4959-ae28" name="Vehicle:" primary="false"/>
@@ -6762,9 +6780,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="fb93-5d17-0d26-e0a4" name="Two Turret Mounted Gravis Autocannons" hidden="false" collective="false" import="true" type="upgrade">
+                    <selectionEntry id="fb93-5d17-0d26-e0a4" name="Two Turret Mounted Exterminator Autocannons" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="149">
                       <entryLinks>
-                        <entryLink id="2f8a-4ca4-f95e-5314" name="Gravis Autocannon" hidden="false" collective="false" import="true" targetId="8a23-e57d-b4a8-14a9" type="selectionEntry">
+                        <entryLink id="2f8a-4ca4-f95e-5314" name="Exterminator Autocannon" hidden="false" collective="false" import="true" targetId="682a-c2bd-16c-db51" type="selectionEntry">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06ee-c70e-4301-c69b" type="min"/>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0830-5f1f-4b1f-ee46" type="max"/>
@@ -6775,9 +6793,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
                     </selectionEntry>
-                    <selectionEntry id="4472-8cb0-1c2b-90a6" name="Turret Mounted Gravis Lascannons" hidden="false" collective="false" import="true" type="upgrade">
+                    <selectionEntry id="4472-8cb0-1c2b-90a6" name="Turret Mounted Gravis Heavy Lascannons" hidden="false" collective="false" import="true" type="upgrade" publicationId="9fab-fea7-a93c-2074" page="149">
                       <entryLinks>
-                        <entryLink id="85bf-2522-ddd1-409b" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
+                        <entryLink id="85bf-2522-ddd1-409b" name="Gravis Heavy Lascannon" hidden="false" collective="false" import="true" targetId="2013-7e81-b563-e7ac" type="selectionEntry">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="122a-7c8e-e02b-6e6f" type="min"/>
                             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc68-3087-d760-bef8" type="max"/>
@@ -7639,7 +7657,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97a5-e6c4-498a-6f00" type="max"/>
                           </constraints>
                           <profiles>
-                            <profile id="0a38-b438-3798-9322" name="Auxilia Gunner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+                            <profile id="0a38-b438-3798-9322" name="Auxilia Gunner" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit" publicationId="9fab-fea7-a93c-2074" page="147">
                               <modifiers>
                                 <modifier type="increment" field="e8a6-1da9-d384-8727" value="1">
                                   <conditions>
@@ -7658,7 +7676,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">3</characteristic>
                                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
                                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
-                                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
+                                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">4+</characteristic>
                               </characteristics>
                             </profile>
                           </profiles>
@@ -7775,11 +7793,6 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               </constraints>
               <infoLinks>
                 <infoLink id="03de-2559-ae5f-19b1" name="Sentry Protocols" hidden="false" targetId="97aa-da60-3ccc-7152" type="rule"/>
-                <infoLink id="5ee4-5d5f-398d-47a5" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
-                  <modifiers>
-                    <modifier type="set" field="name" value="Bulky (4)"/>
-                  </modifiers>
-                </infoLink>
                 <infoLink id="2662-3817-b139-6c7c" name="Tercio" hidden="false" targetId="6516-f81d-457b-a2cc" type="rule"/>
                 <infoLink id="7a42-ad21-7547-96ed" name="Furious Charge (X)" hidden="false" targetId="2821-9269-862f-0554" type="rule">
                   <modifiers>
@@ -7797,6 +7810,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <modifier type="set" field="name" value="Firing Protocols (2)"/>
                   </modifiers>
                 </infoLink>
+                <infoLink name="Immobile" hidden="false" id="bf8e-3bc4-c358-b21" type="rule" targetId="a676-e911-8581-8a72"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="0f06-68df-a24d-f08d" name="Infantry Unit Type" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -7827,15 +7841,15 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                           <characteristics>
                             <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Automated Artillery)</characteristic>
                             <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
-                            <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
-                            <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                            <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">-</characteristic>
+                            <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                            <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+                            <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
                             <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                            <characteristic name="I" typeId="62d3-22d7-2d49-52dc">-</characteristic>
+                            <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">-</characteristic>
                             <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
-                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3</characteristic>
+                            <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
@@ -7926,7 +7940,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 <entryLink id="39dd-22fc-73f2-4b47" name="Fear (Feral Cohort)" hidden="false" collective="false" import="true" targetId="aefe-eff6-2961-a445" type="selectionEntry"/>
               </entryLinks>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-20"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7935,12 +7949,16 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
       </costs>
+      <infoLinks>
+        <infoLink name="Artillery Spotters" hidden="false" id="e230-dd89-7019-3f04" type="rule" targetId="a373-9d03-0a41-339e"/>
+      </infoLinks>
     </selectionEntry>
     <selectionEntry id="7040-cbf9-ae05-d34f" name="Malcador Heavy Tank Squadron" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="599e-e4ee-408f-8006" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="46f0-6ee0-d708-646e" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="a0d9-5a0a-c774-22c4" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="0ea2-efb5-b7af-226e" id="8b6b-e61b-8673-9913" primary="false" name="Fast Sub-type:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="be71-2815-0f0e-7740" name="Malcador Heavy Tank" hidden="false" collective="false" import="true" type="model">
@@ -7949,9 +7967,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6339-417a-33de-49d1" type="max"/>
           </constraints>
           <profiles>
-            <profile id="d85b-5161-313e-8863" name="Malcador Heavy Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+            <profile id="d85b-5161-313e-8863" name="Malcador Heavy Tank" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="147">
               <characteristics>
-                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Fast)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
@@ -7967,19 +7985,19 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <infoLink id="e9a8-eab3-25c7-fb46" name="Independent Fire Control" hidden="false" targetId="64ca-719e-b563-e3df" type="rule"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="0b25-2d71-92ea-358f" name="1) May exchange its Hull (Front) Mounted battlecannon for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="75b6-40fb-7a3e-7338">
+            <selectionEntryGroup id="0b25-2d71-92ea-358f" name="1) May exchange its Hull (Front) Mounted Battlecannon for one of the following:" hidden="false" collective="false" import="true" defaultSelectionEntryId="75b6-40fb-7a3e-7338">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d5-e753-8078-0d9c" type="min"/>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae0a-1498-d3ee-8a47" type="max"/>
               </constraints>
               <entryLinks>
                 <entryLink id="75b6-40fb-7a3e-7338" name="Battle Cannon" hidden="false" collective="false" import="true" targetId="7638-4f76-51f0-b0fa" type="selectionEntry"/>
-                <entryLink id="c91f-7c64-7365-ced7" name="Vanquisher Battle Cannon" hidden="false" collective="false" import="true" targetId="196c-cb26-f3e0-e0db" type="selectionEntry">
+                <entryLink id="c91f-7c64-7365-ced7" name="Vanquisher Battle Cannon w/ Co-Axial Autocannon" hidden="false" collective="false" import="true" targetId="ea4a-7e8d-4ea3-a24c" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
                   </costs>
                 </entryLink>
-                <entryLink id="3388-068b-9209-4592" name="Gravis Lascannon" hidden="false" collective="false" import="true" targetId="1fe0-7c96-5200-0e39" type="selectionEntry">
+                <entryLink id="3388-068b-9209-4592" name="Gravis Heavy Lascannon" hidden="false" collective="false" import="true" targetId="2013-7e81-b563-e7ac" type="selectionEntry">
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
                   </costs>
@@ -8003,12 +8021,12 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                 </entryLink>
                 <entryLink id="dc68-bfa9-7008-eb02" name="Demolisher Cannon" hidden="false" collective="false" import="true" targetId="1d4a-05a3-1589-915d" type="selectionEntry">
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
                   </costs>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="3aef-f336-3b44-7f26" name="3) May exchange its Hull (Left) &amp; Hull (Right) Mounted heavy bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9020-c4fb-3589-9f16">
+            <selectionEntryGroup id="3aef-f336-3b44-7f26" name="3) May exchange its Side (Left) &amp; Side (Right) Mounted heavy bolters for:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9020-c4fb-3589-9f16">
               <constraints>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b546-23b9-7c07-9d65" type="min"/>
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37c8-464e-3c0f-cffa" type="max"/>
@@ -8039,7 +8057,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
                     <modifier type="set" field="name" value="Hull (Left) &amp; Hull (Right) Mounted Lascannon"/>
                   </modifiers>
                   <costs>
-                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
+                    <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
                   </costs>
                 </entryLink>
               </entryLinks>
@@ -8124,6 +8142,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <categoryLinks>
             <categoryLink targetId="e2b6-b770-784c-9e95" id="5d45-6227-4a45-bfb0" name="Vehicle:" primary="false"/>
             <categoryLink targetId="9b0d-738c-10e4-4ec1" id="b9bc-dd90-4b4a-a35d" name="Reinforced Sub-type" primary="false"/>
+            <categoryLink targetId="0ea2-efb5-b7af-226e" id="270b-81bb-6e18-69ca" primary="false" name="Fast Sub-type:"/>
           </categoryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -8235,6 +8254,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
         <categoryLink id="877d-1506-c333-394d" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="379b-9b35-3537-5b57" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="a361-f57a-50f8-e582" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="0ea2-efb5-b7af-226e" id="ba2b-4995-a849-506c" primary="false" name="Fast Sub-type:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="f060-c13e-d979-af0d" name="Valdor Tank Destroyer" hidden="false" collective="false" import="true" type="model">
@@ -8243,9 +8263,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26a4-8b17-f351-9ecd" type="max"/>
           </constraints>
           <profiles>
-            <profile id="0171-f3c9-092e-8d7b" name="Valdor Tank Destroyer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+            <profile id="0171-f3c9-092e-8d7b" name="Valdor Tank Destroyer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="147">
               <characteristics>
-                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Fast)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
@@ -8364,7 +8384,11 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <categoryLinks>
             <categoryLink targetId="e2b6-b770-784c-9e95" id="aecb-cd92-4e6f-8f2c" name="Vehicle:" primary="false"/>
             <categoryLink targetId="9b0d-738c-10e4-4ec1" id="cce9-8949-4d9e-b9c4" name="Reinforced Sub-type" primary="false"/>
+            <categoryLink targetId="0ea2-efb5-b7af-226e" id="af9c-889a-3f78-fcfe" primary="false" name="Fast Sub-type:"/>
           </categoryLinks>
+          <infoLinks>
+            <infoLink name="Independent Fire Control" hidden="false" id="52f7-a017-19d6-3933" type="rule" targetId="64ca-719e-b563-e3df"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -8576,8 +8600,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
       <categoryLinks>
         <categoryLink id="2be0-c1f0-c1aa-8dee" name="Vehicle:" hidden="false" targetId="e2b6-b770-784c-9e95" primary="false"/>
         <categoryLink id="e099-bd75-a34a-7a25" name="Reinforced Sub-type" hidden="false" targetId="9b0d-738c-10e4-4ec1" primary="false"/>
-        <categoryLink id="e500-6757-140f-aa62" name="LoW &amp; Primarchs (25% Limit)" hidden="false" targetId="2eaf-32d6-9d1d-d906" primary="false"/>
         <categoryLink name="SA or IM Unit" hidden="false" id="3071-4407-8b63-f5bb" targetId="4aca-2849-7f41-0200" primary="false"/>
+        <categoryLink targetId="7031-469a-1aeb-eab0" id="d22-dd7d-b8a2-f2b2" primary="false" name="Heavy Support:"/>
+        <categoryLink targetId="0ea2-efb5-b7af-226e" id="ac93-4374-884f-e167" primary="false" name="Fast Sub-type:"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="12ee-19a7-66a2-2901" name="Malcador Infernus" hidden="false" collective="false" import="true" type="model">
@@ -8586,9 +8611,9 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6257-2deb-e385-3d58" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a81e-c11f-3267-0cfd" name="Malcador Infernus" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+            <profile id="a81e-c11f-3267-0cfd" name="Malcador Infernus" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="147">
               <characteristics>
-                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced)</characteristic>
+                <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Fast)</characteristic>
                 <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">14&quot;</characteristic>
                 <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
                 <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
@@ -8609,7 +8634,7 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
               <profiles>
                 <profile id="ccb1-43bf-08c2-9169" name="Inferno Cannon" publicationId="15a4-fc68-502d-48a9" page="143" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                   <characteristics>
-                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">Helstorm</characteristic>
+                    <characteristic name="Range" typeId="95ba-cda7-b831-6066">Hellstorm</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">8</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
                     <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Torrent (9&quot;), Breaching (6+), Concussive (1)</characteristic>
@@ -8757,7 +8782,12 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
           <categoryLinks>
             <categoryLink targetId="e2b6-b770-784c-9e95" id="45df-cce8-4b9c-9750" name="Vehicle:" primary="false"/>
             <categoryLink targetId="9b0d-738c-10e4-4ec1" id="2d35-75bd-4015-b826" name="Reinforced Sub-type" primary="false"/>
+            <categoryLink targetId="0ea2-efb5-b7af-226e" id="1583-4e46-d5d9-34f9" primary="false" name="Fast Sub-type:"/>
           </categoryLinks>
+          <infoLinks>
+            <infoLink name="Containment Breach" hidden="false" id="a110-c930-f16-343" type="rule" targetId="2bf6-9fcb-fb98-a11d"/>
+            <infoLink name="Independent Fire Control" hidden="false" id="b93-c26a-2c90-d619" type="rule" targetId="64ca-719e-b563-e3df"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -8766,12 +8796,12 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
     </selectionEntry>
     <selectionEntry id="19c9-f8e8-edff-fa8e" name="Stormhammer" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="3d2f-5e8e-b753-efe9" name="Stormhammer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="3d2f-5e8e-b753-efe9" name="Stormhammer" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="147">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Super-heavy)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10&quot;</characteristic>
             <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">3</characteristic>
-            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
+            <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">13</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">12</characteristic>
             <characteristic name="HP" typeId="a76c-83b1-602f-9e62">12</characteristic>
@@ -8906,6 +8936,14 @@ Once assigned to a unit, the Auxilia Medicae is considered part of that unit and
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="139b-3c0c-0eb8-cbee" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9867-03ff-6252-bdfc" type="max"/>
           </constraints>
+          <infoLinks>
+            <infoLink name="Exoshock (X)" hidden="false" id="4431-39c3-1e03-8162" type="rule" targetId="69ca-318a-b47a-7a3c">
+              <modifiers>
+                <modifier type="set" value="Exoshock (6+)" field="name"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Lance" hidden="false" id="4a62-5de3-4591-d36a" type="rule" targetId="3d6b-9e0b-56f0-8a1e"/>
+          </infoLinks>
         </entryLink>
         <entryLink id="3b44-62c9-6452-49c4" name="Smoke Launchers" hidden="false" collective="false" import="true" targetId="0873-34dd-e52d-d33c" type="selectionEntry">
           <constraints>
@@ -11279,14 +11317,6 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
               <costs>
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
               </costs>
-              <infoLinks>
-                <infoLink name="Bulky (X)" hidden="false" id="668e-6d11-4ac-ca76" type="rule" targetId="676c-7b75-4b6f-9405">
-                  <modifiers>
-                    <modifier type="set" value="Bulky (5)" field="name"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink name="Immobile" hidden="false" id="34d-cae3-ec64-194a" type="rule" targetId="a676-e911-8581-8a72"/>
-              </infoLinks>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -11470,7 +11500,7 @@ If a Weapon Destroyed result is repaired, that weapon may not be used to attack 
           <rules>
             <rule id="05af-452b-0e23-3b16" name="Reborn Cohorts" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false">
               <description>Effects
-• All models with the Infantry Unit Type in a Detachment using this Cohort Doctrine gain a bonus of +1 to their Leadership Characteristic and the Stubborn special rule.
+• All models with the Infantry Unit Type in a Detachment using this Cohort Doctrine gain a bonus of +1 to their Leadership Characteristic, to a maximum of Leadership 10, and the Stubborn Special Rule.
 • When making a Shooting Attack during any Game Turn in which the attacking unit has not Moved, a unit from a Detachment using this Cohort Doctrine may re-roll all failed To Hit rolls of ‘1’.
 
 Limitations
@@ -11507,14 +11537,20 @@ Limitations
           <rules>
             <rule id="a28b-aeef-6d88-8985" name="Armoured Fist Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="71" hidden="false">
               <description>Effects
-• A Detachment using this Cohort Doctrine may select Auxilia Armoured Tercios as non-Compulsory Troops choices. An Auxilia Armoured Tercio selected as a Troops choice may only consist of a single unit, which must be a Solar Auxilia Leman Russ Strike Squadron.
+• A Detachment using this Cohort Doctrine may select Auxilia Armoured Tercios as Troops choices. An Auxilia Armoured Tercio selected as a Troops choice may only consist of a single unit. Auxilia Armoured Tercios selected as Compulsory Troop Choices in a Primary Detachment using this Cohort Doctrine gain the Line Unit Sub-type. The first time in a game that any models with the Infantry Unit Type Disembark from their own Dedicated Transport, they gain the Relentless special rule until the end of that turn. (THIS MUST BE MANUALLY CHECKED)
 • In a Primary Detachment using this Cohort Doctrine, a single Solar Auxilia Armoured Command Section composed of only a single Leman Russ Command Tank, must be selected as a HQ choice. This Leman Russ Command Tank gains the Cohort Doctrines special rule and must be selected as the army’s Warlord and must use the Armoured Legate Warlord trait (see below). A model with the Vehicle Unit Type must be selected as the Warlord of an army using this Cohort Doctrine, regardless of any rules which would require a model to be selected as the army’s Warlord (note this means that some units and Characters cannot be selected as part of this army):
 
 Warlord Trait: Armoured Legate
 A Warlord with this Warlord Trait gains the Cohort Doctrines special rule, a 5+ Invulnerable Save and increases its BS by +1.
 
-Limitations
-• All units composed entirely of models with the Infantry Unit Type must begin the battle Embarked on a model with the Transport Unit Sub-type or in Reserves. (THIS MUST BE MANUALLY CHECKED)</description>
+Limitations (THIS MUST BE MANUALLY CHECKED)
+• All units composed entirely of models with the Infantry Unit Type must
+begin the battle Embarked on a model with the Transport Unit Sub-type
+or in Reserves, unless the unit has the Mechanised Unit Sub-type.
+• A Detachment using this Cohort Doctrine may not include any models
+with a Movement Characteristic of 0 or ‘-’.
+• An army which includes at least one Detachment using this Cohort
+Doctrine may not select any Fortifiction choice.</description>
             </rule>
           </rules>
           <costs>
@@ -11526,8 +11562,10 @@ Limitations
             <rule id="dc68-cb01-b862-110a" name="Penal Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false">
               <description>Effects
 • All models in a unit from a Detachment using this Cohort Doctrine that include models with the Tercio special rule also gain the Furious Charge (1) special rule.
-• Any model in a Detachment using this Cohort Doctrine may replace a lasrifle or volkite charger with a lascarbine, lasgun, stubcarbine, autorifle or shotgun for no additional points cost. In addition, one Auxilia in any Solar Auxilia Rifle Section may replace a lasrifle with a heavy stubber for +5 points per model.
+• Any model with the Infantry Unit Type in a Detachment using this Cohort Doctrine may replace a Lasrifle or Volkite Charger with a Lascarbine, Lasgun, Stubcarbine, Autorifle, Laspistol and Close Combat Weapon, or Shotgun for no additional points cost. In addition, one Auxilia in any Solar Auxilia Rifle Section may replace a Lasrifle with a Heavy Stubber for +5 points per model.
 • All models selected as part of a Solar Auxilia Rifle Section gain the Feel No Pain (6+) special rule – this does not stack with any other variant of this special rule and if the unit has access to any other Feel No Pain (X) special rule, the controlling player must select one to use.
+• Any model in a Detachment using this Cohort Doctrine may replace a
+Close Combat Weapon with a Chainsword for +1 point per model.”
 
 Limitations
 • All models in a Detachment using this Cohort Doctrine with the Close-order Unit Sub-type lose that Unit Sub-type.
@@ -11540,10 +11578,13 @@ Limitations
         </selectionEntry>
         <selectionEntry id="021e-6841-7375-7862" name="Feral Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="1a4f-9ea3-092f-f00e" name="Feral Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="72" hidden="false">
-              <description>Effects
+            <rule id="1a4f-9ea3-092f-f00e" name="Feral Pattern Cohorts" publicationId="9fab-fea7-a93c-2074" page="146" hidden="false">
+              <description>Effects (THIS MUST BE CHECKED MANUALLY)
 • Any unit made up entirely of models with the Infantry Unit Type may be given the Fear (1) special rule for a cost of +25 points per unit.
 • All units that include one or more models with the Tercio special rule gain the Counter-attack (1) special rule while ‘In Formation’.
+• All models with the Infantry Unit Type from a Detachment using this Cohort Doctrine gain a bonus of +1 to their Weapon Skill, to a maximum of 5, for the duration of any player turn in which they make a Successful Charge.
+• Any model in a Detachment using this Cohort Doctrine may replace a Bayonet with a Chain Bayonet for +1 point per model.
+• Any model with the Character Unit Sub-type in a Detachment using this Cohort Doctrine may exchange a Close Combat Weapon for a Chain Axe for +2 points per model.
 
 Limitations
 • All units in a Detachment using this Cohort Doctrine that begin the controlling player’s Assault phase with an enemy unit that is a valid target for a Charge must declare a Charge. If more than one enemy unit is a valid target, the controlling player chooses which enemy unit is the target of the Charge.
@@ -11556,13 +11597,17 @@ Limitations
         </selectionEntry>
         <selectionEntry id="d9a0-4875-fb75-f9a9" name="Siege Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="bf71-d394-4968-20e3" name="Siege Pattern Cohorts" publicationId="15a4-fc68-502d-48a9" page="73" hidden="false">
-              <description>Effects
-• A Detachment using this Cohort Doctrine may select Auxilia Artillery Tercios and Solar Auxilia Armoured Batteries as both Elites and Heavy Support choices.
+            <rule id="bf71-d394-4968-20e3" name="Siege Pattern Cohorts" publicationId="9fab-fea7-a93c-2074" page="146" hidden="false">
+              <description>Effects (THIS MUST BE CHECKED MANUALLY)
+• A Detachment using this Cohort Doctrine may select Auxilia Artillery Tercios and Solar Auxilia Armoured Batteries as both Elites and Heavy Support choices. In addition, they may select Solar Auxilia Artillery Battery squads as both Heavy Support and Fortification choices.
 • When a model from a Detachment using this Cohort Doctrine makes a Shooting Attack with any weapon with the Barrage and/or Blast special rules, the controlling player may choose to re-roll the Scatter dice (but not any D6 rolled to determine the distance of any scatter).
+• Any unit eligible to purchase a Dedicated Transport may instead elect to purchase a Defence Line without occupying a Fortification Force Organisation slot, but the cost in points must be counted towards the army total as usual.
+• When a model from a Detachment using this Cohort Doctrine makes a Shooting Attack with any weapon with the Barrage Special Rule, if the enemy unit they are targeting is in Line of Sight of a friendly model equipped with a Command Vox then it should be counted as firing directly at that enemy unit, even if it is outside of Line of Sight of the firing model.
 
-Limitations
-• All units in a Detachment using this Cohort Doctrine with the option to select a Dedicated Transport must select that option at the normal cost in points – but do not have to start the battle Embarked on that Dedicated Transport.</description>
+Limitations (THIS MUST BE CHECKED MANUALLY)
+• All units in a Detachment using this Cohort Doctrine with the option to select a Dedicated Transport must select that option, or have purchased a Defence Line, at the normal cost in points – If a Dedicated Transport was purchased for a unit, it does not have to start the battle Embarked on that Dedicated Transport.
+• A Detachment using this Cohort Doctrine may only be selected for an
+army’s Primary Detachment.</description>
             </rule>
           </rules>
           <costs>
@@ -11618,10 +11663,10 @@ Limitations
       <description>A Solar Auxilia Rapier Battery must have one Auxilia Gunner per Rapier Carrier in order for all Rapier Carriers to make Shooting Attacks in the Shooting phase. If, at the start of any of the controlling player’s Shooting phases, the Solar Auxilia Rapier Battery contains fewer Auxilia Gunners than Rapier Carriers, then only a number of Rapier Carriers equal to the number of  Auxilia Gunners may make Shooting Attacks in that Shooting phase. In addition, as long as there are at least as many Auxilia Gunners in the unit as there are Rapier Carriers, then the unit cannot be Pinned, automatically passing any Pinning tests it is called upon to take without any dice being rolled (this benefit is lost immediately once the number of Auxilia Gunners is reduced to less than the number of Rapier Carriers in the unit).</description>
     </rule>
     <rule id="a217-f49a-7a73-981d" name="Demolition Vehicle" publicationId="15a4-fc68-502d-48a9" page="131" hidden="false">
-      <description>When a model with this special rule is called upon to make attacks during an Assault, instead of rolling To Hit as normal it instead inflicts one automatic Hit using the profile below on any one  enemy model it is in base contact with (chosen by the player that controls the model with this special rule). Once this Hit is resolved, the model with this special rule is automatically  removed as a casualty (the removal of this model does not add any Wounds to the total used to determine which side has won the Assault).
+      <description>A model with this Special Rule may declare and make charge moves, even if it would normally be prevented from doing so by any Unit Types or Sub-types. When a model with this Special Rule is in combat, at Initiative step 10 it inflicts one automatic hit using the profile below on any one enemy model it is in base contact with (chosen by the player that controls the model with this Special Rule). Once this Hit is resolved, the model with this special rule is automatically removed as a casualty (the removal of this model does not add any Wounds to the total used to determine which side has won the Assault).
 
-Weapon 		Range	Str	AP	Type
-Demo charge		- 	10	1	Melee, Armourbane (Melee), Instant Death, Brutal (2)</description>
+Weapon Range Str AP Type
+Demo charge - 10 1 Melee, Armourbane (Melee), Instant Death, Brutal (2)</description>
     </rule>
     <rule id="2d37-470b-462f-9c99" name="Independent Operators" publicationId="15a4-fc68-502d-48a9" page="133" hidden="false">
       <description>When deployed onto the battlefield (either at the start of the battle, when arriving from Reserves or Disembarking from a model with the Transport Sub-type), all models with this special rule in the same unit must be placed within unit coherency following the normal rules for deploying/Disembarking units, but after deployment or Disembarkation all models in the unit with this special rule are considered to have left the unit, and now form separate units of a single model each. For the remainder of the battle, a model with this special rule is considered a separate unit for all purposes and may not join other units or reform into their original unit. However, the whole unit must be removed as casualties before the opposing player scores any Victory points for the destruction of any model that was part of the unit.</description>

--- a/2022 - LI - Solar Auxilia.cat
+++ b/2022 - LI - Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="46c4-ffd6-affd-72f1" name="LI - Solar Auxilia" revision="2027" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="46c4-ffd6-affd-72f1" name="LI - Solar Auxilia" revision="2028" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <categoryEntries>
     <categoryEntry id="19f3-8727-02db-3ce5" name="Static Artillery" hidden="false">
       <rules>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -620,7 +620,7 @@ Cruel Taskmaster – If any friendly unit with at least one model within 12&quot
           <description>Archmagos Draykavac has the Artificia Machina and Ephemera Incursus Cybertheurgic Arcana, and has all Rites and weapons that are part of those Arcana.</description>
         </rule>
         <rule id="cf9e-42d8-ee4d-f5f3" name="High Techno-arcana: Stataraga" publicationId="bde1-6db1-163b-3b76" page="61" hidden="false">
-          <description>Archmagos Draykavac may be chosen as an HQ choice in a Traitor Allegiance Mechanicum Detachment, and may also be taken as a Troops choice in an army using the Divisio Tactica: Questoris Household. As part of a Questoris Knights Detachment, Archmagos Draykavac allows Castellax Battle-automata Maniples and Vorax Battle-automata Maniples to be chosen as non-Compulsory Troops choices for any Detachment in which he is included</description>
+          <description>Archmagos Draykavac may be chosen as an HQ choice in a Traitor Allegiance Mechanicum Detachment, and may also be taken as a Troops choice in an army using the Divisio Tactica: Questoris Household. As part of a Questoris Knights Detachment, Archmagos Draykavac allows Castellax Battle-automata Maniples and Vorax Battle-automata Maniples to be chosen as non-Compulsory Troops choices for any Detachment in which he is included. In addition, when selected as a Troops Choice in a Questoris Knights Detachment, Archmagos Draykavac gains the Patris Cybernetica Special Rule.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -5058,7 +5058,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                   <infoLinks>
                     <infoLink id="467a-4d09-3317-b057" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
                       <modifiers>
-                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                        <modifier type="set" field="name" value="Hammer of Wrath (2)"/>
                       </modifiers>
                     </infoLink>
                   </infoLinks>
@@ -5074,6 +5074,13 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                         <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c009-b44c-eae9-d23e" type="min"/>
                         <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63b3-1672-08f3-2354" type="max"/>
                       </constraints>
+                      <infoLinks>
+                        <infoLink name="Brutal (X)" hidden="false" id="8524-4cf9-5b-94d0" type="rule" targetId="5079-1fec-d32b-8b84">
+                          <modifiers>
+                            <modifier type="set" value="Brutal (2)" field="name"/>
+                          </modifiers>
+                        </infoLink>
+                      </infoLinks>
                     </entryLink>
                     <entryLink id="48b8-3982-5332-1179" name="Atomantic Deflector" hidden="false" collective="false" import="true" targetId="38fb-9a0b-edef-a497" type="selectionEntry">
                       <constraints>
@@ -5148,9 +5155,15 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                   <infoLinks>
                     <infoLink id="47a6-bf07-a5c0-fa73" name="Hammer of Wrath (X)" hidden="false" targetId="aec0-c3aa-1e4e-1779" type="rule">
                       <modifiers>
-                        <modifier type="set" field="name" value="Hammer of Wrath (1)"/>
+                        <modifier type="set" field="name" value="Hammer of Wrath (2)"/>
                       </modifiers>
                     </infoLink>
+                    <infoLink name="Brutal (X)" hidden="false" id="4b7d-bb4-c398-ebda" type="rule" targetId="5079-1fec-d32b-8b84">
+                      <modifiers>
+                        <modifier type="set" value="Brutal (2)" field="name"/>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink name="Shock Charger" hidden="false" id="c5ee-56b-9ea6-2cbd" type="profile" targetId="6a03-3816-0065-83ff"/>
                   </infoLinks>
                   <entryLinks>
                     <entryLink id="1476-9dd5-0b18-0c13" name="Graviton Ram" hidden="false" collective="false" import="true" targetId="f610-008f-5046-ea99" type="selectionEntry">
@@ -5201,7 +5214,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </modifier>
               </modifiers>
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="35"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="50"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -142,7 +142,10 @@
       <profiles>
         <profile id="d6e7-9365-6336-6a51" name="Ionic Deflector" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an ionic deflector gains a 5+ Invulnerable Save, and any model with an ionic deflector and a Wounds Characteristic gains the Eternal Warrior special rule. In addition, when a model with an ionic deflector loses its last Wound or Hull Point, but before it is removed as a casualty or replaced with a Wreck, all models both friendly and enemy within D6+3&quot; suffer an automatic Hit atStr 8, AP -.</characteristic>
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A model with an Ionic Deflector gains a 5+ Invulnerable Save, and any model with an Ionic Deflector and a Wounds Characteristic that suffers an unsaved Wound with the Instant Death Special Rule is not immediately removed as a casualty, but instead loses D3 Wounds instead of one for each unsaved Wound with the Instant Death Special Rule inflicted on it.
+
+
+In addition, when a model with an Ionic Deflector loses its last Wound or Hull Point, but before it is removed as a casualty or replaced with a Wreck, all models both friendly and enemy within D6+3&quot; suffer an automatic Hit at Str 8, AP -.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -656,6 +659,16 @@ Cruel Taskmaster – If any friendly unit with at least one model within 12&quot
             </modifier>
           </modifiers>
         </infoLink>
+        <infoLink name="Bulky (X)" hidden="false" id="6d80-c1e4-5865-e3da" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="equalTo" value="0" field="selections" scope="8b4c-01f4-f39f-7c55" childId="9dd5-bfd0-50c9-25c2" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" value="Bulky (4)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="535d-121f-5839-a712" name="Infantry:" hidden="false" targetId="8b4f-bfe2-ce7b-f1b1" primary="false"/>
@@ -796,13 +809,16 @@ Cruel Taskmaster – If any friendly unit with at least one model within 12&quot
         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="156e-c211-5f2a-c2d3" type="max"/>
       </constraints>
       <rules>
-        <rule id="84d6-404e-e083-d165" name="Binaric Stratagems*" publicationId="bde1-6db1-163b-3b76" page="102" hidden="false">
+        <rule id="84d6-404e-e083-d165" name="Binaric Stratagems*" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
           <description>At the start of the battle, once both armies have set up all their models, including any units with the Infiltrator special rule, a player that controls any models with this special rule may select one of the effects listed below as part of this special rule. All units with the Kyropatris field generator item of Wargear in the Detachment that includes the model with this special rule gain the chosen effect for the duration of the battle. Note that only a single bonus may be given to the units, regardless of how many models with this special rule are present in the Detachment. If an army includes multiple Detachments that include any models with this special rule, the controlling player must select an effect for each such Detachment and may select the same or different effects for each Detachment:
 
 • Pain Suppression Override: Affected models gain the Feel No Pain (5+) special rule.
 • Explorator Synaesthesis: Models in affected units gain the Move Through Cover special rule.
 • Deconstructive Confluence: Models in affected units gain the Wrecker special rule.
-• Extinction Interlock: Models in the affected units gain the Preferred Enemy (Infantry) special rule.</description>
+• Extinction Interlock: Models in the affected units gain the Preferred Enemy (Infantry) special rule.
+
+
+Note: If a model is not equipped with a Kyropatris Field Generator, they may not claim the benefits of any Special Rule or effect provided by the Binaric Stratagems Special Rule - even if these Special Rules or effects would normally be conferred, such as the Preferred Enemy (X) Special Rule.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -1376,7 +1392,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <infoLinks>
             <infoLink id="eeba-8a20-d62c-cacb" name="Void Shields" hidden="false" targetId="c503-f5b8-3da0-16e6" type="rule">
               <modifiers>
-                <modifier type="set" field="name" value="Void Shields (6)"/>
+                <modifier type="set" field="name" value="Void Shields (8)"/>
               </modifiers>
             </infoLink>
             <infoLink id="5b96-ad84-3640-2604" name="Night Vision" hidden="false" targetId="683e-b4f2-f032-d31b" type="rule"/>
@@ -1627,9 +1643,17 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               </conditionGroups>
             </modifier>
             <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="8cb2-7235-fc34-9983" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="greaterThan" value="0" field="selections" scope="8cb2-7235-fc34-9983" childId="1682-2560-347c-e798" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="8cb2-7235-fc34-9983" childId="3dc3-9018-b7a3-8cf9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="8cb2-7235-fc34-9983" childId="4b90-1389-3b29-3fca" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="8cb2-7235-fc34-9983" childId="e78c-787d-54ca-82c2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="8cb2-7235-fc34-9983" childId="f4a8-b2a3-1c3c-9761" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Character">
               <conditionGroups>
@@ -1682,7 +1706,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <categoryLink id="c1ce-c546-51c-7a97" name="Knight Sub-type" hidden="false" targetId="437f-7773-a0d0-6061" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="8f56-23e7-36bc-47ca" name="Hull (Front) Mounted Twin-Linked Magna Lascannon" publicationId="bde1-6db1-163b-3b76" page="117" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="8f56-23e7-36bc-47ca" name="Two Hull (Front) Mounted Magna Lascannon" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5557-d98a-72c1-c698" type="min"/>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bb0-9d27-cf87-d08c" type="max"/>
@@ -1690,7 +1714,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
           <infoLinks>
             <infoLink id="d466-e7c9-b31a-a118" name="Blast" hidden="false" targetId="1d9a-73ef-5f4f-8bd8" type="rule"/>
             <infoLink id="3fb0-bdb9-2497-6ed0" name="Ordnance" hidden="false" targetId="6c55-22c8-1b01-2105" type="rule"/>
-            <infoLink id="7d6c-1807-4bb6-0ae3" name="Twin-Linked Magna Lascannon" hidden="false" targetId="2af9-d755-936d-0fa8" type="profile"/>
+            <infoLink id="7d6c-1807-4bb6-0ae3" name="Twin-Linked Magna Lascannon" hidden="false" targetId="2af9-d755-936d-0fa8" type="profile">
+              <modifiers>
+                <modifier type="set" value="Magna Lascannon" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
@@ -2169,11 +2197,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
                 <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
@@ -2182,6 +2205,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="f971-ef52-5344-0b26" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="f971-ef52-5344-0b26" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2425,11 +2467,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -2451,6 +2488,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="0a65-543c-19b2-fd34" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="0a65-543c-19b2-fd34" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2706,11 +2762,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -2732,6 +2783,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="8312-7457-e7b6-fd9f" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="8312-7457-e7b6-fd9f" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -2974,11 +3044,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="3706-a84c-678d-b1c6" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -3001,6 +3066,19 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
               <conditions>
                 <condition field="selections" scope="3706-a84c-678d-b1c6" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
               </conditions>
+            </modifier>
+            <modifier type="increment" value="1" field="2490-aa2f-f5db-6070">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="greaterThan" value="0" field="selections" scope="3706-a84c-678d-b1c6" childId="1682-2560-347c-e798" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="3706-a84c-678d-b1c6" childId="3dc3-9018-b7a3-8cf9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="3706-a84c-678d-b1c6" childId="4b90-1389-3b29-3fca" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="3706-a84c-678d-b1c6" childId="e78c-787d-54ca-82c2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                    <condition type="greaterThan" value="0" field="selections" scope="3706-a84c-678d-b1c6" childId="f4a8-b2a3-1c3c-9761" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <characteristics>
@@ -3270,11 +3348,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="7f12-0cc3-9dcd-25bc" value="4">
               <conditions>
                 <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
@@ -3283,6 +3356,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="7b6b-49ab-d71d-e359" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="7b6b-49ab-d71d-e359" childId="63ce-0429-b209-c3e9" shared="true" includeChildSelections="true"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3332,16 +3424,16 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         <categoryLink id="816e-5380-337b-cc9e" name="Knight Sub-type" hidden="false" targetId="437f-7773-a0d0-6061" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="fda6-d2ec-6c49-f60d" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6784-8899-6af2-8432">
+        <selectionEntryGroup id="fda6-d2ec-6c49-f60d" name="Arm Mounted Conversion Destructors" hidden="false" collective="false" import="true" defaultSelectionEntryId="6784-8899-6af2-8432">
           <constraints>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1d9-d7ec-3c9a-c506" type="min"/>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed1b-d84c-4799-0472" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="6784-8899-6af2-8432" name="Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="7c47-e2e9-dc42-e838" type="selectionEntry"/>
+            <entryLink import="true" name="Conversion Destructor" hidden="false" id="49d8-1d6f-f0fb-d3ae" type="selectionEntry" targetId="bc17-b7a5-deed-7bf7"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c21a-be92-c6c2-5931" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac3f-09f6-b607-867e">
+        <selectionEntryGroup id="c21a-be92-c6c2-5931" name="Centerline Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac3f-09f6-b607-867e">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94b3-a011-6ddb-e43d" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0101-c016-8f7f-6ddf" type="max"/>
@@ -3401,6 +3493,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </entryLink>
         <entryLink id="8582-40af-3314-6d1e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ebb-8e01-7d58-9d99" type="selectionEntryGroup"/>
         <entryLink id="7b31-c479-4f1d-5982" name="Dark Blessings" hidden="false" collective="false" import="true" targetId="3995-31e8-e6a2-562a" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Flare Shield" hidden="false" id="9fd1-a96e-6345-824c" type="selectionEntry" targetId="0e77-6285-22bb-1534"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625"/>
@@ -3544,6 +3637,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
               </conditions>
             </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="012b-109f-74d2-2c82" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="012b-109f-74d2-2c82" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <characteristics>
             <characteristic name="Unit Type" typeId="3c44-1e2a-23fe-c9e0">Vehicle (Knight)</characteristic>
@@ -3652,7 +3764,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                     <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
                     <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
                     <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">1</characteristic>
-                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Cumbersome, Armourbane, Instant Death</characteristic>
+                    <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Cumbersome, Armourbane (Melee), Instant Death</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -3730,6 +3842,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </entryLink>
         <entryLink id="5536-d060-252b-fe86" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ebb-8e01-7d58-9d99" type="selectionEntryGroup"/>
         <entryLink id="3149-5fc-4cdf-3e8a" name="Dark Blessings" hidden="false" collective="false" import="true" targetId="3995-31e8-e6a2-562a" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Flare Shield" hidden="false" id="a5d5-edf4-4db0-16a4" type="selectionEntry" targetId="0e77-6285-22bb-1534"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="500"/>
@@ -3842,11 +3955,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -3868,6 +3976,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="6d0e-0d72-d9e2-01d1" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="6d0e-0d72-d9e2-01d1" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -3989,6 +4116,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </entryLink>
         <entryLink id="f279-74fb-5c30-6e2e" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ebb-8e01-7d58-9d99" type="selectionEntryGroup"/>
         <entryLink id="7d53-18e4-255-1dd6" name="Dark Blessings" hidden="false" collective="false" import="true" targetId="3995-31e8-e6a2-562a" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Flare Shield" hidden="false" id="4c89-e5f8-4907-efe8" type="selectionEntry" targetId="0e77-6285-22bb-1534"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="385"/>
@@ -4101,11 +4229,6 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
-              <conditions>
-                <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
-              </conditions>
-            </modifier>
             <modifier type="increment" field="6c5a-df71-fefa-2ee3" value="1">
               <conditionGroups>
                 <conditionGroup type="or">
@@ -4127,6 +4250,25 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
             <modifier type="append" field="3c44-1e2a-23fe-c9e0" value="Psyker">
               <conditions>
                 <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7ad-bd12-1203-4018" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="1">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e78c-787d-54ca-82c2" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f4a8-b2a3-1c3c-9761" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f03-d8c0-0e83-1f6e" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1682-2560-347c-e798" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4b90-1389-3b29-3fca" type="greaterThan"/>
+                    <condition field="selections" scope="1944-033c-5b7e-a378" value="0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3dc3-9018-b7a3-8cf9" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2490-aa2f-f5db-6070" value="2">
+              <conditions>
+                <condition type="greaterThan" value="0" field="selections" scope="1944-033c-5b7e-a378" childId="63ce-0429-b209-c3e9" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -4268,6 +4410,7 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
         </entryLink>
         <entryLink id="5010-4647-a123-b68c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="1ebb-8e01-7d58-9d99" type="selectionEntryGroup"/>
         <entryLink id="f195-fbaa-ebb9-8c71" name="Dark Blessings" hidden="false" collective="false" import="true" targetId="3995-31e8-e6a2-562a" type="selectionEntryGroup"/>
+        <entryLink import="true" name="Flare Shield" hidden="false" id="cc2b-95d1-ceb8-62e6" type="selectionEntry" targetId="0e77-6285-22bb-1534"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="380"/>
@@ -4327,6 +4470,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <modifier type="increment" field="cc42-7ed5-7092-5c84" value="1">
                   <conditions>
                     <condition field="selections" scope="ab78-91e2-bb5c-9da3" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="537f-846d-90e3-2526" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -4668,6 +4816,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
                   <conditions>
                     <condition field="selections" scope="200f-3379-95a3-c3a4" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="1a1b-fa35-a6a2-ca78" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -5039,6 +5192,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                             <condition field="selections" scope="2903-fef6-e839-368b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
                           </conditions>
                         </modifier>
+                        <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="2903-fef6-e839-368b" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                          </conditions>
+                        </modifier>
                       </modifiers>
                       <characteristics>
                         <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica, Heavy)</characteristic>
@@ -5122,6 +5280,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                         <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
                           <conditions>
                             <condition field="selections" scope="2903-fef6-e839-368b" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="2903-fef6-e839-368b" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -5295,6 +5458,11 @@ Invulnerable Saves granted by a mag-inverter shield do not stack with other Invu
                 <modifier type="increment" field="57ee-1126-32a9-5672" value="1">
                   <conditions>
                     <condition field="selections" scope="f144-1079-11ff-019d" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="f144-1079-11ff-019d" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -5618,12 +5786,12 @@ Invulnerable Saves granted by a Mechanicum Protectiva do not stack with other In
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e4-d354-e70d-8649" type="max"/>
           </constraints>
           <profiles>
-            <profile id="11fa-16c9-2547-4274" name="Cybernetica Exortus (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+            <profile id="11fa-16c9-2547-4274" name="Cybernetica Exortus (Cybertheurgic Rite)" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
               <characteristics>
                 <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single friendly unit with a model within 12&quot; which contains at least one model with the Automata Unit Type and apply one of the following effects to all models with the Automata Unit Type in the unit:
-• When making a Charge roll for the unit in the same turn as this Rite is used, roll an additional dice and discard the lowest rolled dice before determining the results of the Charge roll.
+• When making a Charge roll for the unit in the same turn as this Rite is used, as long as the unit contains at least one model with the Automata Unit Type, you may roll an additional dice and discard the lowest rolled dice before determining the results of the Charge roll.
 • The unit (not each individual model) ignores the first Wound inflicted upon it in each Shooting Attack that targets it until the beginning of the controlling player’s next player turn. Simply discard that Wound without allocating it to a model.
-• The unit adds +1 to its BS for the remainder of the Shooting phase in which this power is used.
+• The Controlling Player may choose to add either +1 to its BS or WS until the start of the Controlling Player’s next Shooting Phase.
 • Until the start of the controlling player’s next turn as the Active player, the unit may ignore the restriction against making Reactions imposed by the Automata Unit Type.
 The Cybertheurgist’s controlling player may choose to make a Cybertheurgy check before using this power, if the Check is successful then two different options may be applied to the target unit instead of one. If the Check is failed then no options may be chosen and the Cybertheurgist suffers Cybertheurgic Feedback.</characteristic>
               </characteristics>
@@ -5779,9 +5947,9 @@ The Cybertheurgist’s controlling player may choose to make a Cybertheurgy chec
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff24-d09e-b3dc-19dc" type="max"/>
           </constraints>
           <profiles>
-            <profile id="90d2-faf0-e267-7e00" name="Ephemera Perfidiae (Cybertheurgic Rite)" publicationId="bde1-6db1-163b-3b76" page="95" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
+            <profile id="90d2-faf0-e267-7e00" name="Ephemera Perfidiae (Cybertheurgic Rite)" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false" typeId="5405-b3c6-e8d0-4e77" typeName="Psychic Power">
               <characteristics>
-                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single enemy unit with a model within 12&quot; that is entirely composed of models with the Vehicle or Automata Unit Type. The Cybertheurgist’s controlling player may immediately make a Shooting Attack as if they controlled the chosen unit – this Shooting Attack may target any unit that is considered an enemy unit by the Cybertheurgist’s controlling player and is made as Snap Shots. The Cybertheurgist may choose to make a Cybertheurgy check before making this Shooting Attack, if successful the Shooting Attack is made using the Cybertheurgist’s BS and is not made as Snap Shots. If the Check is failed then the Cybertheurgist suffers Cybertheurgic Feedback and no Shooting Attack is made. An enemy unit used to make a Shooting Attack with this Rite may attack normally in its controlling player’s turn and gains the Hatred (Cybertheurgists) special rule for the rest of the battle.</characteristic>
+                <characteristic name="Description" typeId="4c0f-7e2f-586c-9305">Instead of making a Shooting Attack, a Cybertheurgist with this Cybertheurgic Rite may select a single enemy unit with a model within 12&quot; that is entirely composed of models with the Vehicle, Dreadnought, or Automata Unit Type (but not any models with the Super-Heavy, Lumbering, Titan, or Knight Sub-types). The Cybertheurgist’s Controlling Player may immediately make a Shooting Attack as if they controlled the chosen unit – this Shooting Attack may target any unit that is considered an enemy unit by the Cybertheurgist’s Controlling Player and is made as Snap Shots. The Cybertheurgist may choose to make a Cybertheurgy check before making this Shooting Attack, and if successful the Shooting Attack is made using the Cybertheurgist’s BS and is not made as Snap Shots. If the Check is failed then the Cybertheurgist suffers Cybertheurgic Feedback and no Shooting Attack is made. An enemy unit used to make a Shooting Attack with this Rite may attack normally in its Controlling Player’s turn and gains the nHatred (Cybertheurgists) Special Rule for the rest of the battle.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5936,11 +6104,11 @@ The Cybertheurgist’s controlling player may choose to make a Cybertheurgy chec
     </selectionEntry>
     <selectionEntry id="9faf-7242-dc40-c3e5" name="Incunabulan Jet Pack" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="49e3-0125-7461-31f6" name="Incunabulan Jet Pack" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+        <profile id="49e3-0125-7461-31f6" name="Incunabulan Jet Pack" publicationId="9fab-fea7-a93c-2074" page="142" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
-            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Incunabulan jet packs may choose to increase its Move Characteristic by +6&quot; and ignore terrain while Moving during the Movement phase. A unit that ends or begins its movement in Dangerous Terrain will still need to take Dangerous Terrain tests as normal, even when employing Incunabulan jet packs and treats Difficult Terrain as Dangerous Terrain. In addition to the bonus to Move during the Movement phase, a unit composed entirely of models with Incunabulan jet packs may make an additional Move of 6&quot; during the Shooting phase. This Move must be taken after the unit has completed any Shooting Attacks, is not limited by the weapons fired by that unit during the Shooting phase and ignores terrain in the same manner as moves made using a Incunabulan jet pack in the Movement phase.
+            <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Incunabulan jet packs may choose to increase its Move Characteristic by +6&quot; and ignore terrain while Moving during the Movement phase. A unit that ends or begins its movement in Dangerous Terrain will still need to take Dangerous Terrain tests as normal, even when employing Incunabulan jet packs and treats Difficult Terrain as Dangerous Terrain. In addition to the bonus to Move during the Movement phase, a unit composed entirely of models with Incunabulan jet packs may make an additional Move of 6&quot; during the Shooting phase. This Move must be taken after the unit has completed any Shooting Attacks, is not limited by the weapons fired by that unit during the Shooting phase and ignores terrain in the same manner as moves made using a Incunabulan jet pack in the Movement phase. This extra move can only be made in the Controlling Player&apos;s own Shooting Phase.
 Any model with an Incunabulan jet pack also gains the Bulky (2) and Deep Strike special rules, or if it already has the Bulky (2) special rule it gains the Bulky (3) special rule instead. Models with an Incunabulan jet pack may Embark on models with the Transport Unit Sub-type, contrary to the normal Transport rules, but still must take into account their size due to the Bulky (X) special rule.
-During any Reaction that allows a unit to Move, a unit composed entirely of models with Incunabulan jet packs increases the distance of that Move by 6 and allows it to ignore terrain in the same manner as other Incunabulan jet pack moves.</characteristic>
+During any Reaction that allows a unit to Move, a unit composed entirely of models with Incunabulan jet packs increases the distance of that Move by 6 and allows it to ignore terrain in the same manner as other Incunabulan jet pack moves. A model with an activated Incunabulan Jet Pack may move over both friendly and enemy models or units without penalty - but must end its Movement at least 1&quot; away from any model from another unit, and ignores the effects of any Difficult, Dangerous, or Impassable Terrain they move over as they make their move, though they must still take Dangerous Terrain Tests as normal should they start or end their move in terrain that would require them to do so. It should be noted that, for the purposes of Reactions, an Incunabulan Jet Pack is classed as having being activated for the purposes of moving over any models or terrain.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5964,7 +6132,8 @@ During any Reaction that allows a unit to Move, a unit composed entirely of mode
         <profile id="94a1-e8ec-8bb1-1d1c" name="Utan Jump Booster" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
           <characteristics>
             <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Utan jump boosters may set its Move Characteristic to a value of 12 for the duration of the controlling player’s turn. This allows the unit to move up to 12&quot;, regardless of the Movement Characteristic shown on its profile and gain any other benefits of a Movement Characteristic of 12 (including the bonus to Charge distance, see the Horus Heresy: Age of Darkness rulebook, page 181). In addition, the unit ignores terrain while Moving and Charging. A unit that ends or begins its movement or a Charge in Dangerous Terrain will still need to take Dangerous Terrain tests as normal, even when employing Utan jump boosters, and treats all Difficult Terrain as Dangerous Terrain.
-A unit composed entirely of models with Utan jump boosters may not Run. During Reactions made in any Phase, a unit composed entirely of models with Utan jump boosters may not activate them to gain any bonus to their Movement Characteristic. Any model with an Utan jump booster also gains the Deep Strike special rule. Additionally, models with an Utan jump booster may Embark on models with the Transport Unit Sub-type, contrary to the normal Transport rules, but still must take into account their Unit Type and their size due to the Bulky (X) special rule.</characteristic>
+A unit composed entirely of models with Utan jump boosters may not Run. During Reactions made in any Phase, a unit composed entirely of models with Utan jump boosters may not activate them to gain any bonus to their Movement Characteristic. Any model with an Utan jump booster also gains the Deep Strike special rule. Additionally, models with an Utan jump booster may Embark on models with the Transport Unit Sub-type, contrary to the normal Transport rules, but still must take into account their Unit Type and their size due to the Bulky (X) special rule.
+A model with an activated Utan Jump Booster may move over both friendly and enemy models or units without penalty - but must end its Movement at least 1&quot; away from any model from another unit, and ignores the effects of any Difficult, Dangerous, or Impassable Terrain they move over as they make their move, though they must still take Dangerous Terrain Tests as normal should they start or end their move in terrain that would require them to do so.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7371,8 +7540,8 @@ The Cybertheurgist’s controlling player may choose to make a Cybertheurgy chec
       <selectionEntries>
         <selectionEntry id="f4a8-b2a3-1c3c-9761" name="Dolorous" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="272c-bf85-64da-42b6" name="Dolorous" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
-              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1, and gains the Character Unit Sub-type and the Dolorous special rule.
+            <rule id="272c-bf85-64da-42b6" name="Dolorous" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic &amp; Hull Points by +1, and gains the Character Unit Sub-type and the Dolorous special rule.
 Dolorous: A model with this special rule may attempt to make Sweeping Advances (as an exception to the normal rules for models with the Knight Unit Sub-type).</description>
             </rule>
           </rules>
@@ -7392,8 +7561,8 @@ Dolorous: A model with this special rule may attempt to make Sweeping Advances (
         </selectionEntry>
         <selectionEntry id="e78c-787d-54ca-82c2" name="Arbalester" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="fd5a-d962-431f-ae84" name="Arbalester" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false">
-              <description>A model with this upgrade increases its Ballistic Skill Characteristic by +1 and gains the Character Unit Sub-type and Arbalester special rule.
+            <rule id="fd5a-d962-431f-ae84" name="Arbalester" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
+              <description>A model with this upgrade increases its Ballistic Skill Characteristic &amp; Hull Points by +1 and gains the Character Unit Sub-type and Arbalester special rule.
 Arbalester: When a model with this special rule is required to make a Scatter roll, roll an additional Scatter dice and the model’s controlling player chooses which is used to determine the results of the Scatter roll.</description>
             </rule>
           </rules>
@@ -7418,9 +7587,9 @@ Arbalester: When a model with this special rule is required to make a Scatter ro
             <constraint field="selections" scope="force" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d855-dfe1-4f37-d3c0" type="max"/>
           </constraints>
           <rules>
-            <rule id="a2e6-ad4f-c2a3-8821" name="Seneschal (0-1)" publicationId="bde1-6db1-163b-3b76" page="88" hidden="false">
+            <rule id="a2e6-ad4f-c2a3-8821" name="Seneschal (0-1)" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
               <description>Only a single unit in a Questoris Household Detachment may be upgraded to have the Seneschal rank, and an Acastus Knight Porphyrion or Acastus Knight Asterius may not be given this upgrade.
-A model with this upgrade gains the Character Unit Sub-type and increases its Weapon Skill and Ballistic Skill Characteristics by +1. In addition, if the Questoris Household Detachment is the Primary Detachment of the army, then a model with this upgrade must be chosen as the army’s Warlord. If selected as the army’s Warlord, a model with this upgrade automatically gains the Master of the Household Warlord Trait:</description>
+A model with this upgrade gains the Character Unit Sub-type and increases its Weapon Skill and Ballistic Skill Characteristics by +1. A Knight which selects the Seneschal Household Rank instead increases its Hull Points Characteristic by +2. In addition, if the Questoris Household Detachment is the Primary Detachment of the army, then a model with this upgrade must be chosen as the army’s Warlord. If selected as the army’s Warlord, a model with this upgrade automatically gains the Master of the Household Warlord Trait:</description>
             </rule>
           </rules>
           <costs>
@@ -7429,8 +7598,8 @@ A model with this upgrade gains the Character Unit Sub-type and increases its We
         </selectionEntry>
         <selectionEntry id="3dc3-9018-b7a3-8cf9" name="Aucteller" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="24dc-2122-1e74-497b" name="Aucteller" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
-              <description>A model with this upgrade increases its Weapon Skill Characteristic by +1 and gains the Character Unit Sub-type and the Aucteller special rule.
+            <rule id="24dc-2122-1e74-497b" name="Aucteller" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
+              <description>A model with this upgrade increases its Weapon Skill Characteristic &amp; Hull Points by +1 and gains the Character Unit Sub-type and the Aucteller special rule.
 Aucteller: When engaged in a Challenge against an enemy model with the Knight, Titan or Monstrous Unit Sub-type, the Primarch Unit Type or a model with a Wounds Characteristic of 8 or higher, a model with this special rule gains +1 Weapon Skill and +1 Attack. This bonus to Weapon Skill is in addition to the +1 Weapon Skill increase from the Aucteller upgrade detailed above.</description>
             </rule>
           </rules>
@@ -7442,7 +7611,7 @@ Aucteller: When engaged in a Challenge against an enemy model with the Knight, T
           <rules>
             <rule id="e7b6-ec43-a395-cc62" name="Implacable" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
               <description>A model with this upgrade increases its Hull Points by +1, gains the Character Unit Sub-type and the Implacable special rule.
-Implacable: No attack targeting a model with this special rule may inflict more than a single Hull Point of damage, including those attacks with the Exoshock (X) special rule</description>
+Implacable: An attack targeting a model with this Special Rule reduces the number of Hull Points of damage inflicted from any attack by -1, to a minimum of 1, and reduces all rolls on the vehicle damage table by 1.</description>
             </rule>
           </rules>
           <costs>
@@ -7451,8 +7620,8 @@ Implacable: No attack targeting a model with this special rule may inflict more 
         </selectionEntry>
         <selectionEntry id="4b90-1389-3b29-3fca" name="Preceptor" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false" collective="false" import="true" type="upgrade">
           <rules>
-            <rule id="191d-7d24-b533-cf66" name="Preceptor" publicationId="bde1-6db1-163b-3b76" page="89" hidden="false">
-              <description>A model with this upgrade increases its Ballistic Skill Characteristic by +1 and gains the Character Unit Sub-type and Preceptor special rule.
+            <rule id="191d-7d24-b533-cf66" name="Preceptor" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
+              <description>A model with this upgrade increases its Ballistic Skill Characteristic &amp; Hull Points by +1 and gains the Character Unit Sub-type and Preceptor special rule.
 Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at least one model within 6&quot; of a friendly model with this special rule increase the Leadership of all models in the unit to 9.</description>
             </rule>
           </rules>
@@ -7470,8 +7639,8 @@ Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at lea
             </modifier>
           </modifiers>
           <rules>
-            <rule id="78f9-6bee-4c5d-5802" name="Uhlan" publicationId="bde1-6db1-163b-3b76" page="89 &amp; FAQ" hidden="false">
-              <description>A model with this upgrade increases its Movement Characteristic by +4 and gains the Character Unit Sub-type and the Scout and Outflank special rules. An Acastus Knight Porphyrion may not be given this upgrade.</description>
+            <rule id="78f9-6bee-4c5d-5802" name="Uhlan" publicationId="9fab-fea7-a93c-2074" page="139" hidden="false">
+              <description>A model with this upgrade increases its Movement Characteristic by +4 and gains the Character Unit Sub-type and the Scout and Outflank special rules. In addition, its Hull Points are increased by +1. An Acastus Knight Porphyrion may not be given this upgrade.</description>
             </rule>
           </rules>
           <costs>
@@ -7527,6 +7696,7 @@ Preceptor: Any units of Armiger Warglaives or Armiger Helverins that have at lea
 • Opus Viscera: If a model with the Battlesmith (X) special rule in a Detachment that includes a model with this special rule is in base contact with at least one model in a unit comprised of only models with the Infantry Unit Type during the Shooting phase, they can attempt to enhance that unit instead of making a Shooting Attack. Roll a D6. If the result is equal to or more than the value listed in brackets as part of the Battlesmith (X) rule, then one of the following effects may be applied to the unit this model is in base contact with:
 - Restore a lost Wound. This will not return a model that has been previously removed from the battle.
 - The unit may immediately move a number of inches equal to twice the Initiative Characteristic of the majority of models in the unit. This movement is not Running, and therefore, if the unit did not Run in the Movement phase, it may still make Shooting Attacks and declare a Charge as normal for the remainder of the turn.
+- This ability may not be used on any unit which is locked in combat.
 
 • The Sanguine Hook: A model with this special rule gains the Ephemera Lacyraemarta Cybertheurgic Arcana, but may not select any other Cybertheurgic Arcana from those available with the Cybertheurgist special rule.</description>
             </rule>
@@ -8102,7 +8272,7 @@ When deployed onto the battlefield (either at the start of the battle or when ar
       <description>A model with this special rule ignores all Psychic Powers and Cybertheurgic Rites and Attacks made by Psychic and Cybertheurgic Weapons. In addition, a model with this special rule ignores the effects of the Haywire and Disruption (X) special rules. In all cases, weapons which benefit from these special rules must attempt to damage a model with this special rule normally using the attack’s Strength value. In addition, all friendly Mechanicum units with at least one model within 24&quot; of a model with this special rule gain the Fearless special rule.</description>
     </rule>
     <rule id="f83c-9442-8102-5da4" name="Pride of Place" publicationId="bde1-6db1-163b-3b76" page="106" hidden="false">
-      <description>A model with this special rule may not embark upon any model with the Transport Unit Sub-type, regardless of its Unit Type or any special rules the model with the Transport Sub-type may have.</description>
+      <description>A model with this special rule may not embark upon any model with the Transport Unit Sub-type, regardless of its Unit Type or any special rules the model with the Transport Sub-type may have. A model which has this Special Rule changes their Armour Save to 2+. In addition, a model with this Special Rule gains the Bulky (X) Special Rule, where X is equal to the model’s starting Wounds Characteristic.</description>
     </rule>
     <rule id="f420-6cdb-5d9b-ef30" name="Cybertheurgic Focus" publicationId="bde1-6db1-163b-3b76" page="94" hidden="false">
       <description>Before making any To Hit rolls with this weapon, the Cybertheurgist must make a Cybertheurgy check. If the Check is passed then the Cybertheurgist may attack as normal using the profile shown for this weapon. If the Check is failed then the Cybertheurgist suffers Cybertheurgic Feedback, and if the model is not removed as a casualty then it may attack as normal but may not use this weapon.</description>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -6975,12 +6975,12 @@ A model with an activated Utan Jump Booster may move over both friendly and ene
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1e4-cf60-50bc-d906" type="max"/>
           </constraints>
           <profiles>
-            <profile id="bb7e-ba2c-cf50-870" name="Despoiler cannon" publicationId="6bcf-2297-2bcd-51be" page="15" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+            <profile id="bb7e-ba2c-cf50-870" name="Despoiler Cannon" publicationId="9fab-fea7-a93c-2074" page="172" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="95ba-cda7-b831-6066">24&quot;</characteristic>
                 <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">10</characteristic>
                 <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">3</characteristic>
-                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Blast (3&quot;), Sunder, Rending (5+), Brutal (3)</characteristic>
+                <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Ordnance 1, Blast (3&quot;), Sunder, Rending (5+), Brutal (3), Wrecker</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7001,6 +7001,8 @@ A model with an activated Utan Jump Booster may move over both friendly and ene
                 <modifier type="set" field="name" value="Blast (3&quot;)"/>
               </modifiers>
             </infoLink>
+            <infoLink name="Ordnance" hidden="false" id="9d44-c9e4-5e1-5dd6" type="rule" targetId="6c55-22c8-1b01-2105"/>
+            <infoLink name="Wrecker" hidden="false" id="4740-57e5-9503-ea73" type="rule" targetId="ba77-a802-55df-da67"/>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>

--- a/2022 - Mech Library.cat
+++ b/2022 - Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="7265-8b7a-50ae-51ec" name="Mech Library" revision="2043" battleScribeVersion="2.03" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="7265-8b7a-50ae-51ec" name="Mech Library" revision="2044" battleScribeVersion="2.03" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="4086-0589-f010-e688" name="Titan Legion Min Troop/LoW" hidden="false"/>
     <categoryEntry id="57a1-ae47-ff1b-36e4" name="Cybertheurgist" publicationId="bde1-6db1-163b-3b76" page="92-96" hidden="false"/>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -428,6 +428,9 @@
         <categoryLink id="2ffa-2a46-fc9a-a923" name="Fast Attack:" hidden="false" targetId="20ef-cd01-a8da-376e" primary="true"/>
         <categoryLink id="8578-ba1d-17f6-7c6e" name="Unit:" hidden="false" targetId="36c3-e85e-97cc-c503" primary="false"/>
       </categoryLinks>
+      <costs>
+        <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="-20"/>
+      </costs>
     </entryLink>
     <entryLink id="71b9-6a72-a0cb-b43b" name="Inar Satarael" hidden="true" collective="false" import="false" targetId="e26f-a72f-8ea2-1641" type="selectionEntry">
       <modifiers>
@@ -995,6 +998,11 @@
         </infoLink>
         <infoLink id="7e8b-641d-fb93-4424" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
         <infoLink id="310c-f07b-6e82-263c" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
+        <infoLink name="Bulky (X)" hidden="false" id="31f3-474a-6cbc-5525" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (5)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bf8-9627-3e73-b8bc" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -1480,6 +1488,11 @@
         <infoLink id="454d-0a38-bcde-faa1" name="Stubborn" hidden="false" targetId="7989-1f2c-a43d-82ae" type="rule"/>
         <infoLink id="73b1-9db2-87ee-a964" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
         <infoLink id="64c8-70e7-2021-4bd2" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
+        <infoLink name="Bulky (X)" hidden="false" id="4e16-af47-2983-b140" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (4)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="7d92-0210-bdb9-cd3a" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -3231,6 +3244,11 @@ This unit may be upgraded freely as described in their profile, though they may 
                     <condition field="selections" scope="e713-beb2-95dd-51cb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" field="e593-6b3c-f169-04f0" value="2+">
+                  <conditions>
+                    <condition field="selections" scope="e713-beb2-95dd-51cb" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Cybernetica)</characteristic>
@@ -3537,6 +3555,11 @@ This unit may be upgraded freely as described in their profile, though they may 
                     <condition field="selections" scope="c731-8052-ca8a-0b37" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc2a-46fe-bbf3-6ba2" type="equalTo"/>
                   </conditions>
                 </modifier>
+                <modifier type="set" value="2+" field="e593-6b3c-f169-04f0">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="0e08-6b7e-8fff-1f02" childId="cc2a-46fe-bbf3-6ba2" shared="true" percentValue="false" includeChildSelections="true" includeChildForces="false"/>
+                  </conditions>
+                </modifier>
               </modifiers>
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Automata (Antigrav, Cybernetica)</characteristic>
@@ -3574,9 +3597,10 @@ This unit may be upgraded freely as described in their profile, though they may 
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd7c-394f-e7cf-3bc2" type="max"/>
               </constraints>
               <profiles>
-                <profile id="e90a-5837-2524-80f0" name="Stratos Thrusters" publicationId="bde1-6db1-163b-3b76" page="130" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
+                <profile id="e90a-5837-2524-80f0" name="Stratos Thrusters" publicationId="9fab-fea7-a93c-2074" page="142" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
                   <characteristics>
-                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Stratos thrusters may set its Move Characteristic to a value of 16&quot; for the duration of the controlling player’s turn. This allows the unit to move up to 16&quot;, regardless of the Movement Characteristic shown on its profile and gain any other benefits of a Movement Characteristic of 16&quot; (including the bonus to Charge distance). In addition, Stratos thrusters allow units to hover above the battlefield and thus ignore the effects of Difficult Terrain and Dangerous Terrain at all times.</characteristic>
+                    <characteristic name="Description" typeId="347e-ee4a-764f-6be3">A unit composed entirely of models with Stratos thrusters may set its Move Characteristic to a value of 16&quot; for the duration of the controlling player’s turn. This allows the unit to move up to 16&quot;, regardless of the Movement Characteristic shown on its profile and gain any other benefits of a Movement Characteristic of 16&quot; (including the bonus to Charge distance). In addition, Stratos thrusters allow units to hover above the battlefield and thus ignore the effects of Difficult Terrain and Dangerous Terrain at all times.
+On a Game Turn in which a model armed with Stratos Thrusters activates them, they may elect to gain the Skyfire Special Rule for all Ranged Weapons they are armed with. In addition, a model equipped with Stratos Thrusters also gains the Deep Strike Special Rule. A model with an activated set of Stratos Thrusters may move over both friendly and enemy models or units without penalty - but must end its Movement at least 1&quot; away from any model from another unit, and ignores the effects of any Difficult, Dangerous, or Impassable Terrain they move over as they make their move, though they must still take Dangerous Terrain Tests as normal should they start or end their move in terrain that would require them to do so.”</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -4060,7 +4084,7 @@ This unit may be upgraded freely as described in their profile, though they may 
           <profiles>
             <profile id="110b-b86e-c1d0-0936" name="Ordinatus Dispersion Shield" publicationId="bde1-6db1-163b-3b76" page="126" hidden="false" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item">
               <characteristics>
-                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">For the duration of the first Game Turn, all Shooting Attacks made against a model with an Ordinatus dispersion shield that target the model’s Front or Side Armour values, or any indirect Shooting Attacks (such as those with the Barrage special rule) are reduced by -2 Strength, and any Explodes results on the Vehicle Damage table are ignored.</characteristic>
+                <characteristic name="Description" typeId="347e-ee4a-764f-6be3">For the duration of the first Game Turn, all Shooting Attacks made against a model with an Ordinatus dispersion shield that target the model’s Front or Side Armour values, or any indirect Shooting Attacks (such as those with the Barrage special rule) are reduced by -2 Strength, and any Explodes results on the Vehicle Damage table are ignored. In subsequent Game Turns after the first, the Ordinatus Dispersion Shield counts as a Flare Shield.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -4257,7 +4281,10 @@ At the beginning of each of the controlling player’s Shooting phases for the r
       <rules>
         <rule id="9d8c-1ee2-4e7c-70c3" name="Archmagos Anacharis Scoria" hidden="false"/>
         <rule id="94ad-dd9a-c902-2f99" name="Rites of the Beast" publicationId="bde1-6db1-163b-3b76" page="63" hidden="false">
-          <description>Anacharis Scoria has the Artificia Machina, Artificia Cybernetica, and Ephemera Incursus Cybertheurgic Arcana, and has all Rites and weapons that are part of those Arcana.</description>
+          <description>Anacharis Scoria has the Artificia Machina, Artificia Cybernetica, Ephemera Incursus, and Anima Malefica Cybertheurgic Arcana, and has all Rites and weapons that are part of those Arcana.
+
+
+In addition, Archmagos Anacharis Scoria provides all effects, benefits, and rules (and gains any wargear, Special Rules, or other effects applicable to himself) that an Archmagos with the Cybernetica Arcana would to the detachment he is in.</description>
         </rule>
       </rules>
       <infoLinks>
@@ -4292,6 +4319,11 @@ At the beginning of each of the controlling player’s Shooting phases for the r
         <infoLink id="4e05-29af-baba-ee5a" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
         <infoLink id="96e9-3018-859e-8010" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink name="Stubborn" hidden="false" id="fd79-af2f-3a8c-3a41" type="rule" targetId="7989-1f2c-a43d-82ae"/>
+        <infoLink name="Bulky (X)" hidden="false" id="efa1-8125-460f-5ec7" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (7)" field="name"/>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -4344,10 +4376,9 @@ At the beginning of each of the controlling player’s Shooting phases for the r
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d3-cfe8-18b0-26ed" type="max"/>
           </constraints>
           <profiles>
-            <profile id="a23c-8539-83e1-b021" name="Forbidden Protocols" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
+            <profile id="a23c-8539-83e1-b021" name="Forbidden Protocols" publicationId="9fab-fea7-a93c-2074" page="138" hidden="false" typeId="a0e6-a7b4-d55d-85b8" typeName="Warlord Trait">
               <characteristics>
-                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly units made up entirely of models with the Automata Unit Type that have at least one model within 6&quot; of this Warlord may make Reactions, ignoring the usual restriction in the Automata Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Anacharis Scoria has not been
-removed as a casualty.�</characteristic>
+                <characteristic name="Text" typeId="c68e-2cda-b67b-baca">Any friendly units made up entirely of models with the Automata Unit Type that have at least one model within 6&quot; of this Warlord may make Reactions, ignoring the usual restriction in the Automata Unit Type. In addition, an army whose Warlord has this Trait may make an additional Reaction in the Movement phase as long as Anacharis Scoria has not been removed as a casualty. Note that this Warlord Trait can affect a unit which Archmagos Anacharis Scoria has joined, even though this would normally not be permitted as the unit would no longer be a unit containing only Automata.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -5142,17 +5173,14 @@ removed as a casualty.�</characteristic>
     <selectionEntry id="1905-926d-628c-a411" name="Mechanicum Tarantula Sentry Gun Battery" publicationId="3886-76e5-438f-159f" page="5" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="5031-49fb-20c7-6b28" name="Automated Artillery Sub-type" hidden="false" targetId="c036-66e2-4e07-c2b8" type="rule"/>
-        <infoLink id="75b7-cca2-2185-b466" name="Bulky (X)" hidden="false" targetId="676c-7b75-4b6f-9405" type="rule">
-          <modifiers>
-            <modifier type="set" field="name" value="Bulky (4)"/>
-          </modifiers>
-        </infoLink>
         <infoLink id="1b4a-4ba2-96e6-6de9" name="Sentry Protocols" hidden="false" targetId="97aa-da60-3ccc-7152" type="rule"/>
         <infoLink id="8043-a3d5-9770-e212" name="Firing Protocols (X)" hidden="false" targetId="32a3-f599-5c92-2945" type="rule">
           <modifiers>
             <modifier type="set" field="name" value="Firing Protocols (2)"/>
           </modifiers>
         </infoLink>
+        <infoLink name="Fearless" hidden="false" id="b635-b6b7-8ab0-3757" type="rule" targetId="b48c-d7e1-2a83-2f5b"/>
+        <infoLink name="Immobile" hidden="false" id="cb68-3f7a-3e27-75ed" type="rule" targetId="a676-e911-8581-8a72"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ae3d-aa42-c8ba-a4f9" name="Artillery Sub-type" hidden="false" targetId="6f99-c178-6f9d-fb63" primary="false"/>
@@ -5195,13 +5223,13 @@ removed as a casualty.�</characteristic>
                   <characteristics>
                     <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Automated Artillery)</characteristic>
                     <characteristic name="Move" typeId="893e-2d76-8f04-44e5">-</characteristic>
-                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">1</characteristic>
-                    <characteristic name="BS" typeId="74ae-c840-0036-d244">2</characteristic>
-                    <characteristic name="S" typeId="e478-41d4-a092-48a8">1</characteristic>
-                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">4</characteristic>
+                    <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">-</characteristic>
+                    <characteristic name="BS" typeId="74ae-c840-0036-d244">3</characteristic>
+                    <characteristic name="S" typeId="e478-41d4-a092-48a8">5</characteristic>
+                    <characteristic name="T" typeId="c32b-5fdd-3fbe-9b1f">5</characteristic>
                     <characteristic name="W" typeId="57ee-1126-32a9-5672">2</characteristic>
-                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">1</characteristic>
-                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
+                    <characteristic name="I" typeId="62d3-22d7-2d49-52dc">-</characteristic>
+                    <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">-</characteristic>
                     <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">5</characteristic>
                     <characteristic name="Save" typeId="e593-6b3c-f169-04f0">3+</characteristic>
                   </characteristics>
@@ -5308,7 +5336,7 @@ removed as a casualty.�</characteristic>
       <profiles>
         <profile id="d83f-c6ef-8eae-4e5f" name="Inar Satarael" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
           <characteristics>
-            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Unique, Monsterous, Antigrav, Cybertheurgist, Character)</characteristic>
+            <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Unique, Monsterous, Cybertheurgist, Character)</characteristic>
             <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
             <characteristic name="WS" typeId="cc42-7ed5-7092-5c84">4</characteristic>
             <characteristic name="BS" typeId="74ae-c840-0036-d244">5</characteristic>
@@ -5337,6 +5365,12 @@ removed as a casualty.�</characteristic>
         </infoLink>
         <infoLink id="c868-b7ac-ecef-44f3" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
         <infoLink id="4bae-d7d8-90fb-f037" name="Feudal Hierarchy" hidden="false" targetId="7d4f-c9a9-f9c0-b49a" type="rule"/>
+        <infoLink name="Bulky (X)" hidden="false" id="f478-13b6-8cb3-cc09" type="rule" targetId="676c-7b75-4b6f-9405">
+          <modifiers>
+            <modifier type="set" value="Bulky (5)" field="name"/>
+          </modifiers>
+        </infoLink>
+        <infoLink name="Born of Steel" hidden="false" id="ae7-23d1-713b-393d" type="rule" targetId="c10a-a327-c9d6-1ea8"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="12a1-ade9-ce31-301a" name="Monstrous Sub-type" hidden="false" targetId="7d95-f9d1-440a-67bd" primary="false"/>
@@ -5616,27 +5650,6 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a7e-46ef-ea49-5eca" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="274c-cd83-3203-f1ad" name="Lascannon" hidden="false" collective="false" import="true" targetId="b252-5a86-6e0f-218b" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Sponson Mounted Lascannons"/>
-              </modifiers>
-            </entryLink>
-            <entryLink id="0cf2-0aba-fa81-1516" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="43f5-3815-6b3a-a363" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Sponson Mounted Plasma Cannons"/>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0033-2f3e-ef5a-1855" name="Multi-Melta" hidden="false" collective="false" import="true" targetId="9332-3834-cf3a-56b4" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="name" value="Sponson Mounted Multi-Meltas"/>
-              </modifiers>
-              <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
-              </costs>
-            </entryLink>
             <entryLink id="0271-debd-659f-5297" name="Twin-linked Heavy Bolter" hidden="false" collective="false" import="true" targetId="d03c-9f7e-84fa-d6e8" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Sponson Mounted Twin-linked Heavy Bolters"/>
@@ -5645,6 +5658,27 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
             <entryLink id="d22c-c576-7717-cde2" name="Flamestorm Cannon" hidden="false" collective="false" import="true" targetId="af97-b307-a484-4fbe" type="selectionEntry">
               <modifiers>
                 <modifier type="set" field="name" value="Sponson Mounted Flamestorm Cannons"/>
+              </modifiers>
+            </entryLink>
+            <entryLink import="true" name="Gravis Lascannon" hidden="false" id="f420-bc4c-6807-e46b" type="selectionEntry" targetId="1fe0-7c96-5200-0e39">
+              <modifiers>
+                <modifier type="set" value="Sponson Mounted Gravis Lascannons" field="name"/>
+              </modifiers>
+            </entryLink>
+            <entryLink import="true" name="Gravis Plasma Cannon" hidden="false" id="8202-bf2a-32bc-e496" type="selectionEntry" targetId="32ad-6250-29c7-5466">
+              <modifiers>
+                <modifier type="set" value="Sponson Mounted Plasma Cannons" field="name"/>
+              </modifiers>
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+              </costs>
+            </entryLink>
+            <entryLink import="true" name="Gravis Melta Cannon" hidden="false" id="e56-88c2-1613-d697" type="selectionEntry" targetId="ef6c-f656-171a-03e1">
+              <costs>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="20"/>
+              </costs>
+              <modifiers>
+                <modifier type="set" value="Sponson Mounted Gravis Melta Cannon" field="name"/>
               </modifiers>
             </entryLink>
           </entryLinks>
@@ -5664,7 +5698,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
     </selectionEntry>
     <selectionEntry id="bd83-b47d-1f37-1159" name="Macrocarid Explorator" publicationId="3886-76e5-438f-159f" page="7" hidden="false" collective="false" import="true" type="unit">
       <profiles>
-        <profile id="bf44-a73f-e84f-2132" name="Macrocarid Explorator" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+        <profile id="bf44-a73f-e84f-2132" name="Macrocarid Explorator" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle" publicationId="9fab-fea7-a93c-2074" page="143">
           <characteristics>
             <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Transport)</characteristic>
             <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
@@ -5672,7 +5706,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
             <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">14</characteristic>
             <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">14</characteristic>
             <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">14</characteristic>
-            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">5</characteristic>
+            <characteristic name="HP" typeId="a76c-83b1-602f-9e62">6</characteristic>
             <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">26</characteristic>
             <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e">One Access Point on each side of the hull.</characteristic>
           </characteristics>
@@ -5809,18 +5843,24 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4c5-cbe9-ecfa-f0cc" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="f689-cc20-4318-874a" name="Demolisher Cannon Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="f689-cc20-4318-874a" name="Demolisher Cannon Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
                         <characteristic name="Transport Capacity" typeId="0c90-79e2-f768-e547">-</characteristic>
                         <characteristic name="Access Points" typeId="e217-1b1e-9494-3e3e"/>
                       </characteristics>
+                    </profile>
+                    <profile name="New Profile" hidden="false" id="f598-ac27-df74-e45" typeId="2a1f-7837-f0ef-be44" typeName="Wargear Item" publicationId="9fab-fea7-a93c-2074" page="143">
+                      <characteristics>
+                        <characteristic name="Description" typeId="347e-ee4a-764f-6be3">The centerline cannon equip to this mount is counted as &apos;Artillery&apos; weapon for those rules which affect such a weapon.</characteristic>
+                      </characteristics>
+                      <alias>Artillery Mount</alias>
                     </profile>
                   </profiles>
                   <categoryLinks>
@@ -5914,6 +5954,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -5928,12 +5972,12 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f421-2cc4-307d-eae8" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="b02c-e47d-6ac8-9ea1" name="Earthshaker Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="b02c-e47d-6ac8-9ea1" name="Earthshaker Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6033,6 +6077,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6041,18 +6089,18 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
             </selectionEntry>
             <selectionEntry id="df41-78c2-829f-e754" name="Gravis Melta Array Artillery Tank" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
-                <selectionEntry id="7568-7ece-c8a8-7299" name="Gravis Melta Array Artillery Tank" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="7568-7ece-c8a8-7299" name="Melta Cannon Array Artillery Tank" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b49-98c8-e0a7-782c" type="max"/>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad40-46ef-c5f9-8356" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="ca67-3129-f325-4d5f" name="Gravis Melta Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="ca67-3129-f325-4d5f" name="Gravis Melta Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6124,9 +6172,9 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="fe25-742c-c52c-69e7" name="Gravis Melta Cannon Array" hidden="false" collective="false" import="true" targetId="f2fc-27b6-983d-092b" type="selectionEntry">
+                    <entryLink id="fe25-742c-c52c-69e7" name="Melta Cannon" hidden="false" collective="false" import="true" targetId="7a16-0e23-c633-c668" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="name" value="Turret Mounted Gravis Melta Cannon Array"/>
+                        <modifier type="set" field="name" value="Turret Mounted Melta Cannon Array"/>
                       </modifiers>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db0d-c466-1141-efb6" type="max"/>
@@ -6152,6 +6200,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="145"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6166,12 +6218,12 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7581-0457-9a55-b115" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="bed8-a2e3-2361-8163" name="Magna Laser Destroyer Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="bed8-a2e3-2361-8163" name="Magna Laser Destroyer Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6271,6 +6323,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="135"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6285,12 +6341,12 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cd8-6a39-6f78-e317" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="f60c-dcf7-5f58-5620" name="Medusa Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="f60c-dcf7-5f58-5620" name="Medusa Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6364,7 +6420,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <entryLinks>
                     <entryLink id="9f63-7675-3e24-c50d" name="Medusa Mortar" hidden="false" collective="false" import="true" targetId="aafc-7435-8805-0e0f" type="selectionEntry">
                       <modifiers>
-                        <modifier type="set" field="name" value="Centreline Mounted Medusa Siege Mortar"/>
+                        <modifier type="set" field="name" value="Centreline Mounted Medusa Mortar"/>
                       </modifiers>
                       <constraints>
                         <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3be5-7d68-56a1-6f3b" type="max"/>
@@ -6390,6 +6446,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6404,12 +6464,12 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52e1-03e4-6280-2ebc" type="min"/>
                   </constraints>
                   <profiles>
-                    <profile id="d6ab-59e5-b2e8-ddf4" name="Artillery Tank" publicationId="3886-76e5-438f-159f" page="8" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
+                    <profile id="d6ab-59e5-b2e8-ddf4" name="Artillery Tank" publicationId="9fab-fea7-a93c-2074" page="143" hidden="false" typeId="2fae-b053-3f78-e7b2" typeName="Vehicle">
                       <characteristics>
-                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
+                        <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle (Reinforced, Bombard)</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6509,6 +6569,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="175"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6528,7 +6592,7 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                         <characteristic name="Unit Type" typeId="e555-4aed-dfcc-c0b4">Vehicle</characteristic>
                         <characteristic name="Move" typeId="3614-4a2d-bffb-90e4">10</characteristic>
                         <characteristic name="BS" typeId="51fb-b7d9-aa59-863d">4</characteristic>
-                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">11</characteristic>
+                        <characteristic name="Front" typeId="0ef8-a648-01d0-08ee">13</characteristic>
                         <characteristic name="Side" typeId="f150-c0dc-c192-9cb3">11</characteristic>
                         <characteristic name="Rear" typeId="8d4e-2aea-fffc-d556">10</characteristic>
                         <characteristic name="HP" typeId="a76c-83b1-602f-9e62">3</characteristic>
@@ -6628,6 +6692,10 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="125"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="add" value="9b0d-738c-10e4-4ec1" field="category"/>
+                    <modifier type="add" value="d5df-57ac-8f3c-097b" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <costs>
@@ -6684,6 +6752,9 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                   <costs>
                     <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="Hull (Rear) Mounted Hunter-Killer Missile" field="name"/>
+                  </modifiers>
                 </entryLink>
                 <entryLink id="7cfb-dd51-1be0-0f72" name="Searchlights" hidden="false" collective="false" import="true" targetId="4ae3-79b4-6051-505e" type="selectionEntry">
                   <constraints>
@@ -6703,13 +6774,13 @@ Additionally, each time Inar Satarael makes a successful Invulnable Save on a ro
                 <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d82-6d51-dd19-c5fe" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="ab2f-5de5-4a4e-e6ac" name="Twin-linked Earthshaker Cannon" hidden="false" collective="false" import="true" targetId="cbd7-2fa5-1aba-e754" type="selectionEntry">
+            <entryLink import="true" name="Earthshaker Battery" hidden="false" id="9765-b90b-47e3-dce8" type="selectionEntry" targetId="1815-c1cd-170-1d3">
               <modifiers>
-                <modifier type="set" field="name" value="Centreline (Rear) Mounted twin-linked Earthshaker Cannon"/>
+                <modifier type="set" value="Centreline (Rear) Mounted Earthshaker Battery" field="name"/>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b949-5511-d0e8-17c8" type="min"/>
-                <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f30-9a31-9d3e-ceaa" type="max"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2409-7ec9-6d4f-2a8d" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6fc7-5cb9-4b9c-a082" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
               </constraints>
             </entryLink>
           </entryLinks>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -2805,9 +2805,9 @@ This unit may be upgraded freely as described in their profile, though they may 
           <entryLinks>
             <entryLink id="a0c8-ef0f-8dd8-2436" name="Maxima Bolter" hidden="false" collective="false" import="true" targetId="1d3e-1b60-d133-ea0d" type="selectionEntry"/>
             <entryLink id="1ce9-93a4-ea75-55b9" name="Volkite Charger" hidden="false" collective="false" import="true" targetId="6f6e-ad55-e093-6503" type="selectionEntry"/>
-            <entryLink id="4ee1-9ccc-acde-97c3" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry">
+            <entryLink id="4ee1-9ccc-acde-97c3" name="Graviton Gun" hidden="false" collective="false" import="true" targetId="5303-5a3e-de51-1707" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="138">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="5"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
             </entryLink>
             <entryLink id="0aed-ef35-dff7-3fbd" name="Irad-Cleanser" hidden="false" collective="false" import="true" targetId="b3c5-237f-e1d2-d9f8" type="selectionEntry">
@@ -2815,9 +2815,9 @@ This unit may be upgraded freely as described in their profile, though they may 
                 <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
               </costs>
             </entryLink>
-            <entryLink id="cebd-f1c6-ae9c-ad75" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry">
+            <entryLink id="cebd-f1c6-ae9c-ad75" name="Phased Plasma-Fusil" hidden="false" collective="false" import="true" targetId="17c6-afe9-c5da-d9b6" type="selectionEntry" publicationId="9fab-fea7-a93c-2074" page="138">
               <costs>
-                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="10"/>
+                <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="15"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2861,7 +2861,7 @@ This unit may be upgraded freely as described in their profile, though they may 
             <constraint field="selections" scope="parent" value="30" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ec5-879e-bc9d-cd5c" type="max"/>
           </constraints>
           <profiles>
-            <profile id="38d0-8350-7538-3992" name="Tech-thralls" publicationId="bde1-6db1-163b-3b76" page="34" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
+            <profile id="38d0-8350-7538-3992" name="Tech-thralls" publicationId="9fab-fea7-a93c-2074" page="138" hidden="false" typeId="4bb2-cb95-e6c8-5a21" typeName="Unit">
               <characteristics>
                 <characteristic name="Unit Type" typeId="ddd7-6f5c-a939-b69e">Infantry (Heavy, Line)</characteristic>
                 <characteristic name="Move" typeId="893e-2d76-8f04-44e5">6</characteristic>
@@ -2873,7 +2873,7 @@ This unit may be upgraded freely as described in their profile, though they may 
                 <characteristic name="I" typeId="62d3-22d7-2d49-52dc">2</characteristic>
                 <characteristic name="A" typeId="f111-2ce5-dd12-d6b0">1</characteristic>
                 <characteristic name="Ld" typeId="e8a6-1da9-d384-8727">6</characteristic>
-                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">6+</characteristic>
+                <characteristic name="Save" typeId="e593-6b3c-f169-04f0">5+</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -2976,6 +2976,11 @@ This unit may be upgraded freely as described in their profile, though they may 
             <infoLink id="5099-7f9f-41b6-aa8a" name="Relentless" hidden="false" targetId="7adf-ac9a-5035-522d" type="rule"/>
             <infoLink id="d084-a195-c74d-1901" name="Support Squad" hidden="false" targetId="768e-56d6-ca52-24ae" type="rule"/>
             <infoLink id="5ed7-a250-aea1-1c1b" name="Guardian Unit Sub-type" hidden="false" targetId="a686-026f-6674-102e" type="rule"/>
+            <infoLink name="Feel No Pain (X)" hidden="false" id="9a7e-6e64-1d1e-aac0" type="rule" targetId="ec46-ff29-32e0-c2aa">
+              <modifiers>
+                <modifier type="set" value="Feel No Pain (5+)" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <costs>
             <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="25"/>
@@ -3256,37 +3261,33 @@ This unit may be upgraded freely as described in their profile, though they may 
                 <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2705-2339-f1ce-d05a" type="max"/>
               </constraints>
               <selectionEntries>
-                <selectionEntry id="5a9d-5fa0-5c22-c3a7" name="Power Blade Arrays With In-Built Light Autocannon*" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="5a9d-5fa0-5c22-c3a7" name="Arlatax Power Claws w/ In-Built Light Autocannon" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="642a-18be-c72d-5cf6" type="max"/>
                   </constraints>
-                  <rules>
-                    <rule id="eef3-4bdf-4f70-9740" name="Power Blade Arrays With In-Built Light Autocannon*" publicationId="bde1-6db1-163b-3b76" page="40" hidden="false">
-                      <description>* An Arlatax with two power blade arrays gains an additional Attack. This additional Attack is not included in the characteristics profile above.</description>
-                    </rule>
-                  </rules>
                   <selectionEntries>
-                    <selectionEntry id="2e78-ef5f-0355-37dc" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="true" import="true" type="upgrade">
+                    <selectionEntry id="2e78-ef5f-0355-37dc" name="Arlatax Power Claws" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" collective="true" import="true" type="upgrade">
                       <profiles>
-                        <profile id="909d-e3f3-25be-a060" name="Power Blade Array" publicationId="bde1-6db1-163b-3b76" page="122" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
+                        <profile id="909d-e3f3-25be-a060" name="Arlatax Power Claws" publicationId="9fab-fea7-a93c-2074" page="174" hidden="false" typeId="1a1a-e592-2849-a5c0" typeName="Weapon">
                           <characteristics>
                             <characteristic name="Range" typeId="95ba-cda7-b831-6066">-</characteristic>
-                            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">User</characteristic>
-                            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">4</characteristic>
-                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Breaching (5+)</characteristic>
+                            <characteristic name="Strength" typeId="24d9-b8e1-a355-2458">+2</characteristic>
+                            <characteristic name="AP" typeId="f7a6-e0d8-7973-cd8d">2</characteristic>
+                            <characteristic name="Type" typeId="2f86-c8b4-b3b4-3ff9">Melee, Shred, Paired Claws</characteristic>
                           </characteristics>
                         </profile>
                       </profiles>
                       <infoLinks>
-                        <infoLink id="50f6-4bb0-0816-6d49" name="Breaching (X)" hidden="false" targetId="a760-f736-1bf3-fa3c" type="rule">
-                          <modifiers>
-                            <modifier type="set" field="name" value="Breaching (5+)"/>
-                          </modifiers>
-                        </infoLink>
+                        <infoLink name="Shred" hidden="false" id="529-8521-e4dc-f272" type="rule" targetId="5e7e-1628-8174-6f2c"/>
                       </infoLinks>
                       <costs>
                         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="0"/>
                       </costs>
+                      <rules>
+                        <rule name="Paired Claws" hidden="false" id="eae7-a425-8c7f-e65f" publicationId="9fab-fea7-a93c-2074" page="174">
+                          <description>When paired with two weapons with this special rule, the model gains +2 attacks instead of the normal +1.</description>
+                        </rule>
+                      </rules>
                     </selectionEntry>
                     <selectionEntry id="8f35-0d01-7cc3-b558" name="Light Autocannon" publicationId="bde1-6db1-163b-3b76" page="114" hidden="false" collective="true" import="true" type="upgrade">
                       <profiles>
@@ -3439,14 +3440,14 @@ This unit may be upgraded freely as described in their profile, though they may 
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="3" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b790-520b-18e0-93da" type="min"/>
-            <constraint field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c6-fc42-abac-9900" type="max"/>
+            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21c6-fc42-abac-9900" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="709c-ef33-7654-982e" name="Two Power Fists*" hidden="false" collective="false" import="true" type="upgrade">
               <modifiers>
                 <modifier type="increment" field="bbe0-7cfc-7c00-94f5" value="1">
                   <repeats>
-                    <repeat field="selections" scope="0750-2aed-2d36-8a82" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0750-2aed-2d36-8a82" value="1" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                 </modifier>
               </modifiers>
@@ -3888,7 +3889,7 @@ This unit may be upgraded freely as described in their profile, though they may 
         </entryLink>
         <entryLink id="13a7-7d49-5ab4-996a" name="Karacnos Mortar Battery" hidden="false" collective="false" import="true" targetId="2b9f-41fb-a0a8-285e" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="name" value="Hull (Front) Mounted Karacnos Mortar Battery"/>
+            <modifier type="set" field="name" value="Centerline Mounted Karacnos Mortar Battery"/>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a70-32d9-7802-97b3" type="max"/>
@@ -3971,7 +3972,7 @@ This unit may be upgraded freely as described in their profile, though they may 
             </selectionEntryGroup>
             <selectionEntryGroup id="cc12-3552-7c4b-7d3b" name="Any Krios in the squadron may take any of the following options:" hidden="false" collective="false" import="true">
               <selectionEntries>
-                <selectionEntry id="36f9-8862-7a52-2928" name="Two Centreline Mounted Volkite Calivers" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="36f9-8862-7a52-2928" name="Two Sponson Mounted Volkite Calivers" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e229-2a5a-7bf3-b572" type="max"/>
                   </constraints>
@@ -4130,6 +4131,7 @@ This unit may be upgraded freely as described in their profile, though they may 
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4471-c23e-3604-fa6e" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Searchlights" hidden="false" id="8327-45e2-b610-411a" type="selectionEntry" targetId="4ae3-79b4-6051-505e"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="1075"/>
@@ -4220,6 +4222,9 @@ At the beginning of each of the controlling player’s Shooting phases for the r
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="800"/>
       </costs>
+      <entryLinks>
+        <entryLink import="true" name="Ordinatus Dispersion Shield" hidden="false" id="61cc-128d-787d-2ce2" type="selectionEntry" targetId="808a-6ab8-6d40-6006"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry id="2185-5fd1-2e59-b467" name="Archmagos Anacharis Scoria" publicationId="bde1-6db1-163b-3b76" page="62" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -4286,6 +4291,7 @@ At the beginning of each of the controlling player’s Shooting phases for the r
         <infoLink id="e5d8-c080-adcd-3c9b" name="Patris Cybernetica" hidden="false" targetId="0893-4bd0-d5a1-14db" type="rule"/>
         <infoLink id="4e05-29af-baba-ee5a" name="Pride of Place" hidden="false" targetId="f83c-9442-8102-5da4" type="rule"/>
         <infoLink id="96e9-3018-859e-8010" name="Traitor" hidden="false" targetId="eff2-8b0e-21da-2f0d" type="rule"/>
+        <infoLink name="Stubborn" hidden="false" id="fd79-af2f-3a8c-3a41" type="rule" targetId="7989-1f2c-a43d-82ae"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="35ea-4280-934d-b8e0" name="Independent Character" hidden="false" targetId="4f07-3d45-4f28-a0c6" primary="false"/>
@@ -4453,16 +4459,16 @@ removed as a casualty.�</characteristic>
         <categoryLink targetId="437f-7773-a0d0-6061" id="5041-362e-f936-5d12" primary="false" name="Knight Sub-type"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2f78-69c3-fd78-43f2" name="Arm Mounted Twin-Linked Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8183-c411-6b59-3742">
+        <selectionEntryGroup id="2f78-69c3-fd78-43f2" name="Arm Mounted Two Conversion Destructor" hidden="false" collective="false" import="true" defaultSelectionEntryId="8183-c411-6b59-3742">
           <constraints>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1560-6f71-ec4a-6a5e" type="min"/>
             <constraint field="selections" scope="parent" value="2" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="025b-76c4-75b0-3105" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="8183-c411-6b59-3742" name="Heavy Conversion Beam Cannon" hidden="false" collective="false" import="true" targetId="7c47-e2e9-dc42-e838" type="selectionEntry"/>
+            <entryLink id="8183-c411-6b59-3742" name="Conversion Destructor" hidden="false" collective="false" import="true" targetId="bc17-b7a5-deed-7bf7" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="932d-e092-656f-2f02" name="Hull (Front) Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="e731-ba8b-286f-1d55">
+        <selectionEntryGroup id="932d-e092-656f-2f02" name="Centerline Mounted Karacnos Mortar Battery" hidden="false" collective="false" import="true" defaultSelectionEntryId="e731-ba8b-286f-1d55">
           <constraints>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff3a-53a8-fd03-986f" type="min"/>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24d8-b111-9437-3776" type="max"/>
@@ -4488,6 +4494,7 @@ removed as a casualty.�</characteristic>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56dd-43cb-72a8-029e" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Flare Shield" hidden="false" id="10e8-ddeb-11ef-8558" type="selectionEntry" targetId="0e77-6285-22bb-1534"/>
       </entryLinks>
       <costs>
         <cost name="Pts" typeId="d2ee-04cb-5f8a-2642" value="625"/>

--- a/2022 - Mechanicum.cat
+++ b/2022 - Mechanicum.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="eb19-d768-b767-c84b" name="Mechanicum" revision="2037" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue" publicationId="3886-76e5-438f-159f">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="eb19-d768-b767-c84b" name="Mechanicum" revision="2038" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue" publicationId="3886-76e5-438f-159f">
   <entryLinks>
     <entryLink id="29c6-0ec7-0162-e817" name="Mechanicum" hidden="false" collective="false" import="false" targetId="ddf5-d792-3146-6e9a" type="selectionEntry">
       <modifiers>

--- a/2022 - Questoris Household.cat
+++ b/2022 - Questoris Household.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="97bf-ffdb-3d04-a0ef" name="Questoris Household" revision="2007" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="97bf-ffdb-3d04-a0ef" name="Questoris Household" revision="2008" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <forceEntries>
     <forceEntry id="28d3-4be2-608d-bf8a" name="0. Questoris Household Force Organisation Chart" hidden="false">
       <categoryLinks>

--- a/2022 - Titan Legions.cat
+++ b/2022 - Titan Legions.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="a9b6-d320-8343-dadc" name="Titan Legions" revision="2012" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="a9b6-d320-8343-dadc" name="Titan Legions" revision="2013" battleScribeVersion="2.03" library="false" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" type="catalogue">
   <forceEntries>
     <forceEntry id="aebe-bed9-b32f-a8ea" name="0. Titan Maniple" hidden="false">
       <categoryLinks>

--- a/Daemon Library.cat
+++ b/Daemon Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="ef0a-91e4-838c-3973" name="Daemon Library" revision="2003" battleScribeVersion="2.03" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="ef0a-91e4-838c-3973" name="Daemon Library" revision="2004" battleScribeVersion="2.03" library="true" gameSystemId="66e4-4610-1d0e-3c25" gameSystemRevision="2001" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="c42-1919-c37e-51f0" name="Encroaching Ruin" hidden="false"/>
     <categoryEntry id="f074-f60a-9aa6-c52a" name="Heedless Slaughter" hidden="false"/>

--- a/Daemon Library.cat
+++ b/Daemon Library.cat
@@ -144,7 +144,7 @@ Additionally, a unit entirely composed of models with this special rule adds +1 
               <description>When selecting a combat at the beginning of the Fight sub-phase, roll a D3 for each unit entirely composed of models with this special rule that is locked in combat. All close combat attacks made by models in the combat with this special rule gain additional special rules corresponding to the D3 roll until the end of that combat phase:
 D3 - Result
 1 - Coruscating Ectoplasma: Concussive (1), Lance
-2 - Lashing Pseudopods: Reach (1)
+2 - Lashing Pseudopods: Reach (1), Rending (6+)
 3 - Vorpal Talons: Shred, Sunder</description>
             </rule>
           </rules>
@@ -172,6 +172,11 @@ D3 - Result
             <infoLink id="9144-7ca8-3e67-ee6e" name="Sunder" hidden="false" targetId="20e2-75cf-bc16-cd8f" type="rule">
               <modifiers>
                 <modifier type="set" field="name" value="Sunder (Formless Distortion)"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Rending (X)" hidden="false" id="4da3-9be4-7ffe-ff3f" targetId="0ac9-fab7-aef3-de1d" type="rule">
+              <modifiers>
+                <modifier type="set" value="Rending (6+) (Formless Distortion)" field="name"/>
               </modifiers>
             </infoLink>
           </infoLinks>


### PR DESCRIPTION
This should be the last of the merges needed to bring all of Panoptica v5.2's Errata and Balance Changes into this BSData Repository.

## Fixed Units
- All of Mechanicum
- All of Imperial Militia (Some Provinces are Manual Checks)
- All of Solar Auxillia (Some Cohorts are Manual Checks)
- All of Daemons
- All of Knights & Titans
- All of Custodes
- All of Sisters of Silence

### Related Issues
- Fixed Issue #4 via 07132cd15b4236602a1e8f3b793ebc4b45b59ef4

## Not done yet
- Some Cohorts & Provinces are Manual Checks due to the intense nature of their changes in Panoptica v5.2. These will be corrected in a future release (if possible).